### PR TITLE
feat(dashboard): DashboardService実装 (T160)

### DIFF
--- a/backend/internal/dto/dashboard_dto.go
+++ b/backend/internal/dto/dashboard_dto.go
@@ -1,0 +1,12 @@
+package dto
+
+// DashboardResponse represents the dashboard summary response
+type DashboardResponse struct {
+	TotalProjects     int64             `json:"total_projects"`
+	ActiveProjects    int64             `json:"active_projects"`
+	CompletedProjects int64             `json:"completed_projects"`
+	TotalRevenue      float64           `json:"total_revenue"`
+	TotalProfit       float64           `json:"total_profit"`
+	AverageProfitRate float64           `json:"average_profit_rate"`
+	RecentProjects    []ProjectResponse `json:"recent_projects"`
+}

--- a/backend/internal/service/dashboard_service.go
+++ b/backend/internal/service/dashboard_service.go
@@ -1,0 +1,138 @@
+package service
+
+import (
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/your-org/project-budget-tracker/backend/internal/dto"
+	apperrors "github.com/your-org/project-budget-tracker/backend/internal/errors"
+	"github.com/your-org/project-budget-tracker/backend/internal/models"
+)
+
+const recentProjectsLimit = 5
+
+// DashboardService handles business logic for the dashboard summary
+type DashboardService struct {
+	db *gorm.DB
+}
+
+// NewDashboardService creates a new DashboardService
+func NewDashboardService(db *gorm.DB) *DashboardService {
+	return &DashboardService{db: db}
+}
+
+// GetDashboard aggregates project counts, budget totals, and recent projects
+// for the given user
+func (s *DashboardService) GetDashboard(userIDStr string) (*dto.DashboardResponse, error) {
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return nil, apperrors.ErrInvalidInput(err)
+	}
+
+	response := &dto.DashboardResponse{}
+
+	counts := []struct {
+		status string
+		dest   *int64
+	}{
+		{"", &response.TotalProjects},
+		{"in_progress", &response.ActiveProjects},
+		{"completed", &response.CompletedProjects},
+	}
+	for _, c := range counts {
+		query := s.db.Model(&models.Project{}).Where("user_id = ?", userID)
+		if c.status != "" {
+			query = query.Where("status = ?", c.status)
+		}
+		if err := query.Count(c.dest).Error; err != nil {
+			return nil, apperrors.ErrDatabaseError(err)
+		}
+	}
+
+	if err := s.aggregateBudgets(userID, response); err != nil {
+		return nil, err
+	}
+
+	if err := s.loadRecentProjects(userID, response); err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+// aggregateBudgets sums revenue/profit over the stored budgets of the user's
+// projects. Profit rates are averaged only over projects with revenue, so
+// projects without revenue do not drag the average down.
+func (s *DashboardService) aggregateBudgets(userID uuid.UUID, response *dto.DashboardResponse) error {
+	var agg struct {
+		TotalRevenue      float64
+		TotalProfit       float64
+		AverageProfitRate float64
+	}
+
+	err := s.db.Model(&models.Budget{}).
+		Joins("JOIN projects ON projects.id = budgets.project_id").
+		Where("projects.user_id = ? AND projects.deleted_at IS NULL", userID).
+		Select(`COALESCE(SUM(budgets.revenue), 0) AS total_revenue,
+			COALESCE(SUM(budgets.profit), 0) AS total_profit,
+			COALESCE(AVG(CASE WHEN budgets.revenue > 0 THEN budgets.profit_rate END), 0) AS average_profit_rate`).
+		Scan(&agg).Error
+	if err != nil {
+		return apperrors.ErrDatabaseError(err)
+	}
+
+	response.TotalRevenue = agg.TotalRevenue
+	response.TotalProfit = agg.TotalProfit
+	response.AverageProfitRate = agg.AverageProfitRate
+	return nil
+}
+
+func (s *DashboardService) loadRecentProjects(userID uuid.UUID, response *dto.DashboardResponse) error {
+	var projects []models.Project
+	err := s.db.
+		Where("user_id = ?", userID).
+		Order("updated_at DESC").
+		Limit(recentProjectsLimit).
+		Find(&projects).Error
+	if err != nil {
+		return apperrors.ErrDatabaseError(err)
+	}
+
+	response.RecentProjects = make([]dto.ProjectResponse, len(projects))
+	for i := range projects {
+		response.RecentProjects[i] = *toDashboardProjectResponse(&projects[i])
+	}
+	return nil
+}
+
+// toDashboardProjectResponse converts a Project model to ProjectResponse DTO
+func toDashboardProjectResponse(project *models.Project) *dto.ProjectResponse {
+	response := &dto.ProjectResponse{
+		ID:        project.ID,
+		UserID:    project.UserID,
+		Name:      project.Name,
+		Status:    project.Status,
+		CreatedAt: project.CreatedAt,
+		UpdatedAt: project.UpdatedAt,
+	}
+
+	if project.Description != nil && *project.Description != "" {
+		response.Description = project.Description
+	}
+
+	if project.BudgetAmount != nil {
+		response.BudgetAmount = project.BudgetAmount
+	}
+
+	if project.StartDate != nil {
+		formatted := project.StartDate.Format("2006-01-02")
+		response.StartDate = &formatted
+	}
+
+	if project.EndDate != nil {
+		formatted := project.EndDate.Format("2006-01-02")
+		response.EndDate = &formatted
+	}
+
+	return response
+}

--- a/backend/internal/service/dashboard_service_test.go
+++ b/backend/internal/service/dashboard_service_test.go
@@ -1,0 +1,168 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/your-org/project-budget-tracker/backend/internal/models"
+	"github.com/your-org/project-budget-tracker/backend/internal/service"
+)
+
+func setupDashboardTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// AutoMigrate cannot be used here: the models declare the PostgreSQL-only
+	// default uuid_generate_v4(), which sqlite rejects
+	ddl := []string{
+		`CREATE TABLE users (
+			id TEXT PRIMARY KEY, email TEXT NOT NULL, password_hash TEXT NOT NULL,
+			name TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member',
+			created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+		`CREATE TABLE projects (
+			id TEXT PRIMARY KEY, user_id TEXT NOT NULL, name TEXT NOT NULL,
+			description TEXT, status TEXT NOT NULL DEFAULT 'planning',
+			budget_amount REAL, start_date DATE, end_date DATE,
+			created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+		`CREATE TABLE budgets (
+			id TEXT PRIMARY KEY, project_id TEXT NOT NULL UNIQUE,
+			revenue REAL DEFAULT 0, total_cost REAL DEFAULT 0,
+			profit REAL DEFAULT 0, profit_rate REAL DEFAULT 0,
+			currency TEXT NOT NULL DEFAULT 'JPY',
+			created_at DATETIME, updated_at DATETIME)`,
+	}
+	for _, stmt := range ddl {
+		require.NoError(t, db.Exec(stmt).Error)
+	}
+	return db
+}
+
+func createDashboardTestUser(t *testing.T, db *gorm.DB) *models.User {
+	user := &models.User{
+		ID:           uuid.New(),
+		Email:        uuid.NewString() + "@example.com",
+		PasswordHash: "hash",
+		Name:         "Test User",
+		Role:         "member",
+	}
+	require.NoError(t, db.Create(user).Error)
+	return user
+}
+
+func createDashboardTestProject(t *testing.T, db *gorm.DB, userID uuid.UUID, name, status string) *models.Project {
+	project := &models.Project{
+		ID:     uuid.New(),
+		UserID: userID,
+		Name:   name,
+		Status: status,
+	}
+	require.NoError(t, db.Create(project).Error)
+	return project
+}
+
+func createDashboardTestBudget(t *testing.T, db *gorm.DB, projectID uuid.UUID, revenue, totalCost float64) {
+	budget := &models.Budget{
+		ID:        uuid.New(),
+		ProjectID: projectID,
+		Revenue:   revenue,
+		TotalCost: totalCost,
+		Currency:  "JPY",
+	}
+	budget.CalculateProfit()
+	require.NoError(t, db.Create(budget).Error)
+}
+
+func TestDashboardService_GetDashboard(t *testing.T) {
+	db := setupDashboardTestDB(t)
+	svc := service.NewDashboardService(db)
+	user := createDashboardTestUser(t, db)
+
+	t.Run("正常系: プロジェクトがない場合はゼロ値を返す", func(t *testing.T) {
+		result, err := svc.GetDashboard(user.ID.String())
+		require.NoError(t, err)
+		assert.Equal(t, int64(0), result.TotalProjects)
+		assert.Equal(t, int64(0), result.ActiveProjects)
+		assert.Equal(t, int64(0), result.CompletedProjects)
+		assert.Equal(t, 0.0, result.TotalRevenue)
+		assert.Equal(t, 0.0, result.TotalProfit)
+		assert.Equal(t, 0.0, result.AverageProfitRate)
+		assert.Empty(t, result.RecentProjects)
+	})
+
+	t.Run("正常系: ステータス別件数と収支が集計される", func(t *testing.T) {
+		p1 := createDashboardTestProject(t, db, user.ID, "進行中プロジェクト", "in_progress")
+		p2 := createDashboardTestProject(t, db, user.ID, "完了プロジェクト", "completed")
+		createDashboardTestProject(t, db, user.ID, "計画中プロジェクト", "planning")
+
+		// p1: 売上100万・コスト60万 → 利益40万・利益率40%
+		createDashboardTestBudget(t, db, p1.ID, 1000000, 600000)
+		// p2: 売上200万・コスト100万 → 利益100万・利益率50%
+		createDashboardTestBudget(t, db, p2.ID, 2000000, 1000000)
+
+		result, err := svc.GetDashboard(user.ID.String())
+		require.NoError(t, err)
+		assert.Equal(t, int64(3), result.TotalProjects)
+		assert.Equal(t, int64(1), result.ActiveProjects)
+		assert.Equal(t, int64(1), result.CompletedProjects)
+		assert.Equal(t, 3000000.0, result.TotalRevenue)
+		assert.Equal(t, 1400000.0, result.TotalProfit)
+		assert.InDelta(t, 45.0, result.AverageProfitRate, 0.01) // (40+50)/2
+		assert.Len(t, result.RecentProjects, 3)
+	})
+
+	t.Run("正常系: 売上ゼロのプロジェクトは利益率平均に含まれない", func(t *testing.T) {
+		db := setupDashboardTestDB(t)
+		svc := service.NewDashboardService(db)
+		user := createDashboardTestUser(t, db)
+
+		p1 := createDashboardTestProject(t, db, user.ID, "売上あり", "in_progress")
+		p2 := createDashboardTestProject(t, db, user.ID, "売上なし", "planning")
+		createDashboardTestBudget(t, db, p1.ID, 1000000, 800000) // 利益率20%
+		createDashboardTestBudget(t, db, p2.ID, 0, 100000)       // 売上ゼロ
+
+		result, err := svc.GetDashboard(user.ID.String())
+		require.NoError(t, err)
+		assert.InDelta(t, 20.0, result.AverageProfitRate, 0.01)
+	})
+
+	t.Run("正常系: 他ユーザーのプロジェクトは集計されない", func(t *testing.T) {
+		other := createDashboardTestUser(t, db)
+		otherProject := createDashboardTestProject(t, db, other.ID, "他人のプロジェクト", "in_progress")
+		createDashboardTestBudget(t, db, otherProject.ID, 9999999, 0)
+
+		result, err := svc.GetDashboard(other.ID.String())
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), result.TotalProjects)
+		assert.Equal(t, 9999999.0, result.TotalRevenue)
+	})
+
+	t.Run("正常系: 最近のプロジェクトは更新日時降順で最大5件", func(t *testing.T) {
+		db := setupDashboardTestDB(t)
+		svc := service.NewDashboardService(db)
+		user := createDashboardTestUser(t, db)
+
+		base := time.Now().Add(-1 * time.Hour)
+		for i := 0; i < 7; i++ {
+			p := createDashboardTestProject(t, db, user.ID, "プロジェクト", "planning")
+			require.NoError(t, db.Model(p).Update("updated_at", base.Add(time.Duration(i)*time.Minute)).Error)
+		}
+
+		result, err := svc.GetDashboard(user.ID.String())
+		require.NoError(t, err)
+		require.Len(t, result.RecentProjects, 5)
+		for i := 1; i < len(result.RecentProjects); i++ {
+			assert.True(t, !result.RecentProjects[i].UpdatedAt.After(result.RecentProjects[i-1].UpdatedAt))
+		}
+	})
+
+	t.Run("異常系: 不正なユーザーIDでエラー", func(t *testing.T) {
+		_, err := svc.GetDashboard("not-a-uuid")
+		require.Error(t, err)
+	})
+}

--- a/backend/scripts/seed.go
+++ b/backend/scripts/seed.go
@@ -121,14 +121,14 @@ func seedProjects(tx *gorm.DB, user *models.User, members []models.Member) error
 		{
 			name:         "ECサイトリニューアル",
 			description:  "既存ECサイトのフルリニューアル。フロントエンド刷新とバックエンドAPI化。",
-			status:       "active",
+			status:       "in_progress",
 			budgetAmount: 5000000,
 			revenue:      6000000,
 			startDate:    today.AddDate(0, -2, 0),
 			endDate:      today.AddDate(0, 2, 0),
 			tasks: []taskSeed{
-				{name: "要件定義", status: "done", plannedHours: 40, actualHours: 36, assignee: pm},
-				{name: "画面デザイン", status: "done", plannedHours: 60, actualHours: 72, assignee: des},
+				{name: "要件定義", status: "completed", plannedHours: 40, actualHours: 36, assignee: pm},
+				{name: "画面デザイン", status: "completed", plannedHours: 60, actualHours: 72, assignee: des},
 				{name: "API実装", status: "in_progress", plannedHours: 120, actualHours: 80, assignee: eng},
 				{name: "フロントエンド実装", status: "todo", plannedHours: 100, actualHours: 0, assignee: eng},
 			},
@@ -155,9 +155,9 @@ func seedProjects(tx *gorm.DB, user *models.User, members []models.Member) error
 			startDate:    today.AddDate(0, -6, 0),
 			endDate:      today.AddDate(0, -1, 0),
 			tasks: []taskSeed{
-				{name: "障害対応", status: "done", plannedHours: 40, actualHours: 55, assignee: eng},
-				{name: "機能改修", status: "done", plannedHours: 80, actualHours: 76, assignee: eng},
-				{name: "運用ドキュメント整備", status: "done", plannedHours: 20, actualHours: 18, assignee: pm},
+				{name: "障害対応", status: "completed", plannedHours: 40, actualHours: 55, assignee: eng},
+				{name: "機能改修", status: "completed", plannedHours: 80, actualHours: 76, assignee: eng},
+				{name: "運用ドキュメント整備", status: "completed", plannedHours: 20, actualHours: 18, assignee: pm},
 			},
 		},
 	}


### PR DESCRIPTION
## 概要

Issue #35 (T160) の実装。ダッシュボードサマリーのビジネスロジック層 `DashboardService` を追加。

## 変更内容

- `backend/internal/dto/dashboard_dto.go`: OpenAPI契約の `Dashboard` スキーマに対応する `DashboardResponse` DTO
- `backend/internal/service/dashboard_service.go`: ユーザー単位の集計サービス
  - プロジェクト件数（全体 / 進行中 `in_progress` / 完了 `completed`）
  - 収支合計: budgetsテーブルをJOINして売上・利益をSUM
  - 平均利益率: 売上が0のプロジェクトを除外して平均（`AVG(CASE WHEN revenue > 0 ...)`）
  - 最近のプロジェクト: 更新日時降順で最大5件
- `backend/internal/service/dashboard_service_test.go`: sqliteインメモリでの単体テスト6ケース
  - 既存の `tests/unit/service` パッケージは破損ファイルによりコンパイル不可のため、コンパイル可能な `internal/service` 配下に配置
- `backend/scripts/seed.go`: ステータス値をDTO列挙値に統一（`active`→`in_progress`、`done`→`completed`）— #121 のフォローアップ修正

## テスト

```
go test ./internal/service/ -run TestDashboardService  → ok (6サブテスト全パス)
go build / go vet / gofmt                              → クリーン
```

ハンドラーとルーティングは次のIssue #36 (T161) / #37 (T162) で実装予定。

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)