### PR TITLE
feat(dashboard): DashboardHandler実装 (T161)

### DIFF
--- a/backend/internal/handler/budget_handler.go
+++ b/backend/internal/handler/budget_handler.go
@@ -65,9 +65,13 @@ func (h *BudgetHandler) UpdateRevenue(c echo.Context) error {
 
 // CreateTimeEntry handles POST /api/v1/time-entries
 func (h *BudgetHandler) CreateTimeEntry(c echo.Context) error {
-	// Get user ID from context
-	userID, ok := c.Get("user_id").(uuid.UUID)
+	// Get user ID from context (AuthMiddleware stores it as a string)
+	userIDStr, ok := c.Get("user_id").(string)
 	if !ok {
+		return c.JSON(http.StatusUnauthorized, dto.ErrorResponse("UNAUTHORIZED", "User not authenticated", nil))
+	}
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil {
 		return c.JSON(http.StatusUnauthorized, dto.ErrorResponse("UNAUTHORIZED", "User not authenticated", nil))
 	}
 

--- a/backend/internal/handler/dashboard_handler.go
+++ b/backend/internal/handler/dashboard_handler.go
@@ -1,0 +1,39 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/your-org/project-budget-tracker/backend/internal/dto"
+	apperrors "github.com/your-org/project-budget-tracker/backend/internal/errors"
+	"github.com/your-org/project-budget-tracker/backend/internal/service"
+)
+
+// DashboardHandler handles HTTP requests for the dashboard
+type DashboardHandler struct {
+	dashboardService *service.DashboardService
+}
+
+// NewDashboardHandler creates a new DashboardHandler
+func NewDashboardHandler(dashboardService *service.DashboardService) *DashboardHandler {
+	return &DashboardHandler{dashboardService: dashboardService}
+}
+
+// GetDashboard handles GET /api/v1/dashboard
+func (h *DashboardHandler) GetDashboard(c echo.Context) error {
+	userID, ok := c.Get("user_id").(string)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, dto.ErrorResponse("UNAUTHORIZED", "User not authenticated", nil))
+	}
+
+	dashboard, err := h.dashboardService.GetDashboard(userID)
+	if err != nil {
+		if appErr, ok := err.(*apperrors.AppError); ok {
+			return c.JSON(appErr.StatusCode, dto.ErrorResponse(appErr.Code, appErr.Message, nil))
+		}
+		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse("INTERNAL_ERROR", "An internal error occurred", nil))
+	}
+
+	return c.JSON(http.StatusOK, dto.SuccessResponse(dashboard))
+}

--- a/backend/internal/handler/dashboard_handler_test.go
+++ b/backend/internal/handler/dashboard_handler_test.go
@@ -1,0 +1,111 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/your-org/project-budget-tracker/backend/internal/dto"
+	"github.com/your-org/project-budget-tracker/backend/internal/handler"
+	"github.com/your-org/project-budget-tracker/backend/internal/models"
+	"github.com/your-org/project-budget-tracker/backend/internal/service"
+)
+
+func setupDashboardHandlerTest(t *testing.T) (*handler.DashboardHandler, *gorm.DB) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// AutoMigrate cannot be used here: the models declare the PostgreSQL-only
+	// default uuid_generate_v4(), which sqlite rejects
+	ddl := []string{
+		`CREATE TABLE users (
+			id TEXT PRIMARY KEY, email TEXT NOT NULL, password_hash TEXT NOT NULL,
+			name TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member',
+			created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+		`CREATE TABLE projects (
+			id TEXT PRIMARY KEY, user_id TEXT NOT NULL, name TEXT NOT NULL,
+			description TEXT, status TEXT NOT NULL DEFAULT 'planning',
+			budget_amount REAL, start_date DATE, end_date DATE,
+			created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+		`CREATE TABLE budgets (
+			id TEXT PRIMARY KEY, project_id TEXT NOT NULL UNIQUE,
+			revenue REAL DEFAULT 0, total_cost REAL DEFAULT 0,
+			profit REAL DEFAULT 0, profit_rate REAL DEFAULT 0,
+			currency TEXT NOT NULL DEFAULT 'JPY',
+			created_at DATETIME, updated_at DATETIME)`,
+	}
+	for _, stmt := range ddl {
+		require.NoError(t, db.Exec(stmt).Error)
+	}
+
+	return handler.NewDashboardHandler(service.NewDashboardService(db)), db
+}
+
+func newDashboardRequestContext(e *echo.Echo) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/dashboard", nil)
+	rec := httptest.NewRecorder()
+	return e.NewContext(req, rec), rec
+}
+
+func TestDashboardHandler_GetDashboard(t *testing.T) {
+	e := echo.New()
+
+	t.Run("正常系: ダッシュボードサマリーを返す", func(t *testing.T) {
+		h, db := setupDashboardHandlerTest(t)
+
+		userID := uuid.New()
+		require.NoError(t, db.Create(&models.User{
+			ID: userID, Email: "demo@example.com", PasswordHash: "hash", Name: "Demo", Role: "member",
+		}).Error)
+		project := &models.Project{ID: uuid.New(), UserID: userID, Name: "P1", Status: "in_progress"}
+		require.NoError(t, db.Create(project).Error)
+		budget := &models.Budget{ID: uuid.New(), ProjectID: project.ID, Revenue: 1000000, TotalCost: 600000, Currency: "JPY"}
+		budget.CalculateProfit()
+		require.NoError(t, db.Create(budget).Error)
+
+		c, rec := newDashboardRequestContext(e)
+		c.Set("user_id", userID.String())
+
+		require.NoError(t, h.GetDashboard(c))
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp struct {
+			Success bool                  `json:"success"`
+			Data    dto.DashboardResponse `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		assert.True(t, resp.Success)
+		assert.Equal(t, int64(1), resp.Data.TotalProjects)
+		assert.Equal(t, int64(1), resp.Data.ActiveProjects)
+		assert.Equal(t, 1000000.0, resp.Data.TotalRevenue)
+		assert.Equal(t, 400000.0, resp.Data.TotalProfit)
+		assert.Len(t, resp.Data.RecentProjects, 1)
+	})
+
+	t.Run("異常系: user_id未設定で401", func(t *testing.T) {
+		h, _ := setupDashboardHandlerTest(t)
+
+		c, rec := newDashboardRequestContext(e)
+
+		require.NoError(t, h.GetDashboard(c))
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+
+	t.Run("異常系: 不正なuser_idで400", func(t *testing.T) {
+		h, _ := setupDashboardHandlerTest(t)
+
+		c, rec := newDashboardRequestContext(e)
+		c.Set("user_id", "not-a-uuid")
+
+		require.NoError(t, h.GetDashboard(c))
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}


### PR DESCRIPTION
## 概要

Issue #36 (T161) の実装。ダッシュボードのHTTPハンドラー層を追加。

## 変更内容

- `backend/internal/handler/dashboard_handler.go`: `GET /api/v1/dashboard` ハンドラー
  - コンテキストの `user_id`（string）からユーザーを特定し、#122 の `DashboardService` に委譲
  - `AppError` をHTTPステータスにマッピング
- `backend/internal/handler/dashboard_handler_test.go`: httptest + sqliteによる単体テスト3ケース（200 / 401 / 400）

## バグ修正（同梱）

`budget_handler.go` の `CreateTimeEntry` で `c.Get("user_id").(uuid.UUID)` とアサーションしていたが、`AuthMiddleware` は `user_id` を **string** で格納するため常に失敗し、**工数記録APIが必ず401を返す**状態だった。string取得 + `uuid.Parse` に修正。

## テスト

```
go test ./internal/handler/ ./internal/service/  → ok
go build / go vet / gofmt                        → クリーン
```

ルーティング登録は次のIssue #37 (T162) で実施。

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)