### PR TITLE
feat(dashboard): ダッシュボードサマリーエンドポイント登録 (T162)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -49,6 +49,7 @@ func main() {
 	taskService := service.NewTaskService(database.GetDB())
 	memberService := service.NewMemberService(database.GetDB())
 	budgetService := service.NewBudgetService(database.GetDB())
+	dashboardService := service.NewDashboardService(database.GetDB())
 
 	// Initialize handlers
 	authHandler := handler.NewAuthHandler(authService)
@@ -56,6 +57,7 @@ func main() {
 	taskHandler := handler.NewTaskHandler(taskService)
 	memberHandler := handler.NewMemberHandler(memberService)
 	budgetHandler := handler.NewBudgetHandler(budgetService)
+	dashboardHandler := handler.NewDashboardHandler(dashboardService)
 
 	// API v1 routes
 	v1 := e.Group("/api/v1")
@@ -95,6 +97,9 @@ func main() {
 	protected.GET("/projects/:id/members", memberHandler.GetProjectMembers)
 	protected.POST("/projects/:id/members", memberHandler.AssignMemberToProject)
 	protected.DELETE("/projects/:id/members/:memberId", memberHandler.RemoveMemberFromProject)
+
+	// Dashboard routes
+	protected.GET("/dashboard", dashboardHandler.GetDashboard)
 
 	// Budget routes
 	protected.GET("/projects/:id/budget", budgetHandler.GetBudget)


### PR DESCRIPTION
## 概要

Issue #37 (T162) の実装。`GET /api/v1/dashboard` をルーターに登録し、ダッシュボードAPIを公開。

## 変更内容

- `backend/cmd/server/main.go`:
  - `DashboardService` / `DashboardHandler`（#122 / #123 で実装）の初期化
  - 認証ミドルウェア配下に `GET /api/v1/dashboard` を登録

## テスト

- `go build ./cmd/...` / `go vet` / `gofmt` クリーン
- ハンドラー・サービスの動作は #122 / #123 の単体テストでカバー済み

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)