### PR TITLE
feat(project): プロジェクト一覧の拡張フィルタ実装 (T163)

### DIFF
--- a/backend/internal/dto/project_dto.go
+++ b/backend/internal/dto/project_dto.go
@@ -63,10 +63,14 @@ type ProjectListResponse struct {
 
 // ProjectListParams represents query parameters for listing projects
 type ProjectListParams struct {
-	Page    int    `query:"page"`
-	PerPage int    `query:"per_page"`
-	Status  string `query:"status"`
-	Search  string `query:"search"`
-	Sort    string `query:"sort"`
-	Order   string `query:"order"`
+	Page          int      `query:"page"`
+	PerPage       int      `query:"per_page"`
+	Status        string   `query:"status"`
+	Search        string   `query:"search"`
+	Sort          string   `query:"sort"`
+	Order         string   `query:"order"`
+	PeriodFrom    string   `query:"period_from"`
+	PeriodTo      string   `query:"period_to"`
+	MinProfitRate *float64 `query:"min_profit_rate"`
+	MaxProfitRate *float64 `query:"max_profit_rate"`
 }

--- a/backend/internal/repository/project_repository.go
+++ b/backend/internal/repository/project_repository.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"time"
+
 	"github.com/google/uuid"
 	"gorm.io/gorm"
 
@@ -45,13 +47,17 @@ func (r *ProjectRepository) GetByIDWithDetails(id uuid.UUID) (*models.Project, e
 
 // ProjectListParams represents parameters for listing projects
 type ProjectListParams struct {
-	UserID uuid.UUID
-	Page   int
-	PerPage int
-	Status string
-	Search string
-	Sort   string
-	Order  string
+	UserID        uuid.UUID
+	Page          int
+	PerPage       int
+	Status        string
+	Search        string
+	Sort          string
+	Order         string
+	PeriodFrom    *time.Time
+	PeriodTo      *time.Time
+	MinProfitRate *float64
+	MaxProfitRate *float64
 }
 
 // List retrieves projects with pagination, filtering, and search
@@ -59,17 +65,40 @@ func (r *ProjectRepository) List(params ProjectListParams) ([]models.Project, in
 	var projects []models.Project
 	var total int64
 
-	query := r.db.Model(&models.Project{}).Where("user_id = ?", params.UserID)
+	query := r.db.Model(&models.Project{}).Where("projects.user_id = ?", params.UserID)
+
+	// Profit-rate filters and sorting read from budgets
+	needsBudgetJoin := params.MinProfitRate != nil || params.MaxProfitRate != nil || params.Sort == "profit_rate"
+	if needsBudgetJoin {
+		query = query.Joins("LEFT JOIN budgets ON budgets.project_id = projects.id")
+	}
 
 	// Apply status filter if provided
 	if params.Status != "" {
-		query = query.Where("status = ?", params.Status)
+		query = query.Where("projects.status = ?", params.Status)
 	}
 
 	// Apply search filter if provided
 	if params.Search != "" {
 		searchPattern := "%" + params.Search + "%"
-		query = query.Where("name ILIKE ? OR description ILIKE ?", searchPattern, searchPattern)
+		query = query.Where("(projects.name ILIKE ? OR projects.description ILIKE ?)", searchPattern, searchPattern)
+	}
+
+	// Apply period filter: keep projects whose duration overlaps the
+	// requested period (open-ended project dates always match)
+	if params.PeriodFrom != nil {
+		query = query.Where("(projects.end_date IS NULL OR projects.end_date >= ?)", *params.PeriodFrom)
+	}
+	if params.PeriodTo != nil {
+		query = query.Where("(projects.start_date IS NULL OR projects.start_date <= ?)", *params.PeriodTo)
+	}
+
+	// Apply profit-rate filters; projects without a budget count as 0%
+	if params.MinProfitRate != nil {
+		query = query.Where("COALESCE(budgets.profit_rate, 0) >= ?", *params.MinProfitRate)
+	}
+	if params.MaxProfitRate != nil {
+		query = query.Where("COALESCE(budgets.profit_rate, 0) <= ?", *params.MaxProfitRate)
 	}
 
 	// Count total records
@@ -78,18 +107,20 @@ func (r *ProjectRepository) List(params ProjectListParams) ([]models.Project, in
 	}
 
 	// Determine sort column
-	sortColumn := "created_at"
+	sortColumn := "projects.created_at"
 	switch params.Sort {
 	case "name":
-		sortColumn = "name"
+		sortColumn = "projects.name"
 	case "start_date":
-		sortColumn = "start_date"
+		sortColumn = "projects.start_date"
 	case "end_date":
-		sortColumn = "end_date"
+		sortColumn = "projects.end_date"
 	case "status":
-		sortColumn = "status"
+		sortColumn = "projects.status"
 	case "created_at":
-		sortColumn = "created_at"
+		sortColumn = "projects.created_at"
+	case "profit_rate":
+		sortColumn = "COALESCE(budgets.profit_rate, 0)"
 	}
 
 	// Determine sort order
@@ -167,10 +198,10 @@ func (r *ProjectRepository) GetProjectStats(projectID uuid.UUID) (*ProjectStats,
 
 // ProjectStats represents project statistics
 type ProjectStats struct {
-	ProjectID          uuid.UUID `json:"project_id"`
-	TotalTasks         int       `json:"total_tasks"`
-	TotalPlannedHours  float64   `json:"total_planned_hours"`
-	TotalActualHours   float64   `json:"total_actual_hours"`
-	CompletedTasks     int       `json:"completed_tasks"`
-	CompletionRate     float64   `json:"completion_rate"`
+	ProjectID         uuid.UUID `json:"project_id"`
+	TotalTasks        int       `json:"total_tasks"`
+	TotalPlannedHours float64   `json:"total_planned_hours"`
+	TotalActualHours  float64   `json:"total_actual_hours"`
+	CompletedTasks    int       `json:"completed_tasks"`
+	CompletionRate    float64   `json:"completion_rate"`
 }

--- a/backend/internal/repository/project_repository_test.go
+++ b/backend/internal/repository/project_repository_test.go
@@ -1,0 +1,145 @@
+package repository_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/your-org/project-budget-tracker/backend/internal/models"
+	"github.com/your-org/project-budget-tracker/backend/internal/repository"
+)
+
+func setupProjectRepoTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// AutoMigrate cannot be used here: the models declare the PostgreSQL-only
+	// default uuid_generate_v4(), which sqlite rejects
+	ddl := []string{
+		`CREATE TABLE projects (
+			id TEXT PRIMARY KEY, user_id TEXT NOT NULL, name TEXT NOT NULL,
+			description TEXT, status TEXT NOT NULL DEFAULT 'planning',
+			budget_amount REAL, start_date DATE, end_date DATE,
+			created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+		`CREATE TABLE budgets (
+			id TEXT PRIMARY KEY, project_id TEXT NOT NULL UNIQUE,
+			revenue REAL DEFAULT 0, total_cost REAL DEFAULT 0,
+			profit REAL DEFAULT 0, profit_rate REAL DEFAULT 0,
+			currency TEXT NOT NULL DEFAULT 'JPY',
+			created_at DATETIME, updated_at DATETIME)`,
+	}
+	for _, stmt := range ddl {
+		require.NoError(t, db.Exec(stmt).Error)
+	}
+	return db
+}
+
+func date(s string) *time.Time {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return &t
+}
+
+func createFilterTestProject(t *testing.T, db *gorm.DB, userID uuid.UUID, name, status string, start, end *time.Time, profitRate *float64) *models.Project {
+	project := &models.Project{
+		ID:        uuid.New(),
+		UserID:    userID,
+		Name:      name,
+		Status:    status,
+		StartDate: start,
+		EndDate:   end,
+	}
+	require.NoError(t, db.Create(project).Error)
+
+	if profitRate != nil {
+		budget := &models.Budget{
+			ID:         uuid.New(),
+			ProjectID:  project.ID,
+			ProfitRate: *profitRate,
+			Currency:   "JPY",
+		}
+		require.NoError(t, db.Create(budget).Error)
+	}
+	return project
+}
+
+func TestProjectRepository_List_ExtendedFilters(t *testing.T) {
+	db := setupProjectRepoTestDB(t)
+	repo := repository.NewProjectRepository(db)
+	userID := uuid.New()
+	rate := func(v float64) *float64 { return &v }
+
+	// 2026-01〜2026-03 / 利益率40%
+	createFilterTestProject(t, db, userID, "Q1プロジェクト", "completed", date("2026-01-01"), date("2026-03-31"), rate(40))
+	// 2026-04〜2026-06 / 利益率10%
+	createFilterTestProject(t, db, userID, "Q2プロジェクト", "in_progress", date("2026-04-01"), date("2026-06-30"), rate(10))
+	// 期間未設定 / 収支未登録
+	createFilterTestProject(t, db, userID, "期間未定プロジェクト", "planning", nil, nil, nil)
+
+	baseParams := func() repository.ProjectListParams {
+		return repository.ProjectListParams{UserID: userID, Page: 1, PerPage: 10}
+	}
+
+	t.Run("期間フィルタ: 重なるプロジェクトのみ返す", func(t *testing.T) {
+		params := baseParams()
+		params.PeriodFrom = date("2026-04-01")
+		params.PeriodTo = date("2026-12-31")
+
+		projects, total, err := repo.List(params)
+		require.NoError(t, err)
+		assert.Equal(t, int64(2), total) // Q2 + 期間未定（オープン期間は常に一致）
+		names := []string{projects[0].Name, projects[1].Name}
+		assert.Contains(t, names, "Q2プロジェクト")
+		assert.Contains(t, names, "期間未定プロジェクト")
+	})
+
+	t.Run("利益率フィルタ: 下限以上のみ返す", func(t *testing.T) {
+		params := baseParams()
+		params.MinProfitRate = rate(20)
+
+		projects, total, err := repo.List(params)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), total)
+		assert.Equal(t, "Q1プロジェクト", projects[0].Name)
+	})
+
+	t.Run("利益率フィルタ: 収支未登録は0%として扱う", func(t *testing.T) {
+		params := baseParams()
+		params.MaxProfitRate = rate(5)
+
+		projects, total, err := repo.List(params)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), total)
+		assert.Equal(t, "期間未定プロジェクト", projects[0].Name)
+	})
+
+	t.Run("利益率ソート: 降順で返す", func(t *testing.T) {
+		params := baseParams()
+		params.Sort = "profit_rate"
+
+		projects, _, err := repo.List(params)
+		require.NoError(t, err)
+		require.Len(t, projects, 3)
+		assert.Equal(t, "Q1プロジェクト", projects[0].Name)
+		assert.Equal(t, "Q2プロジェクト", projects[1].Name)
+		assert.Equal(t, "期間未定プロジェクト", projects[2].Name)
+	})
+
+	t.Run("ステータス + 期間の組み合わせ", func(t *testing.T) {
+		params := baseParams()
+		params.Status = "in_progress"
+		params.PeriodFrom = date("2026-01-01")
+
+		projects, total, err := repo.List(params)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), total)
+		assert.Equal(t, "Q2プロジェクト", projects[0].Name)
+	})
+}

--- a/backend/internal/service/project_service.go
+++ b/backend/internal/service/project_service.go
@@ -153,13 +153,30 @@ func (s *ProjectService) ListProjects(userIDStr string, params dto.ProjectListPa
 	}
 
 	repoParams := repository.ProjectListParams{
-		UserID:  userID,
-		Page:    params.Page,
-		PerPage: params.PerPage,
-		Status:  params.Status,
-		Search:  params.Search,
-		Sort:    params.Sort,
-		Order:   params.Order,
+		UserID:        userID,
+		Page:          params.Page,
+		PerPage:       params.PerPage,
+		Status:        params.Status,
+		Search:        params.Search,
+		Sort:          params.Sort,
+		Order:         params.Order,
+		MinProfitRate: params.MinProfitRate,
+		MaxProfitRate: params.MaxProfitRate,
+	}
+
+	if params.PeriodFrom != "" {
+		from, err := time.Parse("2006-01-02", params.PeriodFrom)
+		if err != nil {
+			return nil, apperrors.ErrValidationFailed("period_from must be in YYYY-MM-DD format")
+		}
+		repoParams.PeriodFrom = &from
+	}
+	if params.PeriodTo != "" {
+		to, err := time.Parse("2006-01-02", params.PeriodTo)
+		if err != nil {
+			return nil, apperrors.ErrValidationFailed("period_to must be in YYYY-MM-DD format")
+		}
+		repoParams.PeriodTo = &to
 	}
 
 	projects, total, err := s.projectRepo.List(repoParams)


### PR DESCRIPTION
## 概要

Issue #38 (T163) の実装。`GET /api/v1/projects` にダッシュボード向けの拡張フィルタを追加。

## 変更内容

### 新しいクエリパラメータ

| パラメータ | 意味 |
|---|---|
| `period_from` / `period_to` (YYYY-MM-DD) | プロジェクト期間が指定期間と**重なる**ものを抽出。開始/終了未設定のプロジェクトは常に一致 |
| `min_profit_rate` / `max_profit_rate` | 利益率(%)での絞り込み。budgetsをLEFT JOINし、収支未登録は0%扱い |
| `sort=profit_rate` | 利益率でのソートを追加 |

### 実装詳細

- `dto/project_dto.go`: クエリパラメータ追加（既存ハンドラーの `c.Bind` がそのまま対応）
- `service/project_service.go`: 日付バリデーション（不正な形式は400）
- `repository/project_repository.go`: JOIN導入に伴い全カラム参照を `projects.` 修飾に統一、検索ORを明示的に括弧で保護、gofmt適用
- `repository/project_repository_test.go`: sqliteによる単体テスト5ケース（期間重複・利益率下限/上限・ソート・複合）

## テスト

```
go test ./internal/repository/ ./internal/service/ ./internal/handler/  → ok
go build / go vet / gofmt                                               → クリーン
```

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)