### PR TITLE
perf(db): KPI集計クエリ最適化インデックス (T164)

### DIFF
--- a/backend/migrations/000008_add_kpi_indexes.down.sql
+++ b/backend/migrations/000008_add_kpi_indexes.down.sql
@@ -1,0 +1,4 @@
+-- KPI集計クエリ最適化用インデックスの削除 (T164)
+DROP INDEX IF EXISTS projects_user_status_idx;
+DROP INDEX IF EXISTS projects_user_updated_idx;
+DROP INDEX IF EXISTS budgets_profit_rate_idx;

--- a/backend/migrations/000008_add_kpi_indexes.up.sql
+++ b/backend/migrations/000008_add_kpi_indexes.up.sql
@@ -1,0 +1,15 @@
+-- KPI集計クエリ最適化用インデックス (T164)
+
+-- ダッシュボードのステータス別件数集計（user_id + status の複合条件）
+CREATE INDEX IF NOT EXISTS projects_user_status_idx
+    ON projects(user_id, status)
+    WHERE deleted_at IS NULL;
+
+-- ダッシュボードの「最近のプロジェクト」（user_id絞り込み + updated_at降順）
+CREATE INDEX IF NOT EXISTS projects_user_updated_idx
+    ON projects(user_id, updated_at DESC)
+    WHERE deleted_at IS NULL;
+
+-- プロジェクト一覧の利益率フィルタ・ソート（budgets JOIN後の絞り込み）
+CREATE INDEX IF NOT EXISTS budgets_profit_rate_idx
+    ON budgets(profit_rate);


### PR DESCRIPTION
## 概要

Issue #39 (T164) の実装。ダッシュボード（#122〜#124）と拡張フィルタ（#125）で追加されたKPI集計クエリ向けのインデックスをマイグレーション `000008` として追加。

## 追加インデックス

| インデックス | 対象クエリ |
|---|---|
| `projects_user_status_idx (user_id, status) WHERE deleted_at IS NULL` | ダッシュボードのステータス別件数集計 |
| `projects_user_updated_idx (user_id, updated_at DESC) WHERE deleted_at IS NULL` | 最近のプロジェクト5件取得 |
| `budgets_profit_rate_idx (profit_rate)` | 利益率フィルタ（min/max_profit_rate）とソート |

既存の単一カラムインデックス（user_id / status / dates / budgets.project_id）は確認済みでそのまま利用。partial index により論理削除行をスキャン対象から除外。

## 検証

- `IF NOT EXISTS` / `DROP INDEX IF EXISTS` により再実行・ロールバックとも冪等
- 適用は `make migrate-up`

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)