### PR TITLE
feat(dashboard): use-dashboardフック実装 (T166)

### DIFF
--- a/frontend/hooks/use-dashboard.ts
+++ b/frontend/hooks/use-dashboard.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import apiClient from '@/lib/api-client';
+import { DashboardResponse } from '@/types/dashboard';
+import { ApiResponse } from '@/types/api';
+
+// API functions
+const dashboardApi = {
+  // Get dashboard summary
+  getDashboard: async (): Promise<DashboardResponse> => {
+    const response = await apiClient.get<ApiResponse<DashboardResponse>>('/dashboard');
+    return (response as any).data;
+  },
+};
+
+// Query keys
+export const dashboardKeys = {
+  all: ['dashboard'] as const,
+  summary: () => [...dashboardKeys.all, 'summary'] as const,
+};
+
+/**
+ * Hook to fetch the dashboard summary (KPIs and recent projects)
+ */
+export function useDashboard() {
+  return useQuery({
+    queryKey: dashboardKeys.summary(),
+    queryFn: dashboardApi.getDashboard,
+  });
+}

--- a/frontend/types/dashboard.ts
+++ b/frontend/types/dashboard.ts
@@ -1,0 +1,12 @@
+import { Project } from './project';
+
+// Dashboard summary response (GET /api/v1/dashboard)
+export interface DashboardResponse {
+  total_projects: number;
+  active_projects: number;
+  completed_projects: number;
+  total_revenue: number;
+  total_profit: number;
+  average_profit_rate: number;
+  recent_projects: Project[];
+}


### PR DESCRIPTION
## 概要

Issue #41 (T166) の実装。ダッシュボードAPI（#124）をフロントエンドから利用するためのTanStack Queryフックを追加。

## 変更内容

- `frontend/types/dashboard.ts`: `DashboardResponse` 型（OpenAPI契約の `Dashboard` スキーマ準拠、`recent_projects` は既存の `Project` 型を再利用）
- `frontend/hooks/use-dashboard.ts`: `useDashboard()` フックと `dashboardKeys` クエリキー（既存の `use-budget.ts` の構成に準拠）

## 検証

- `npm run type-check` (tsc --noEmit) → パス
- `next lint` は main 上で壊れているため実行不可（dependabotのNext.jsバンプ起因とみられる既知の問題。`npm install` 自体も eslint のpeer依存競合で `--legacy-peer-deps` が必要な状態）

利用側のダッシュボードページ実装は #44 (T169) で対応予定。

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)