### PR TITLE
feat(dashboard): プロジェクトテーブルコンポーネント実装 (T168)

### DIFF
--- a/frontend/components/dashboard/project-table.tsx
+++ b/frontend/components/dashboard/project-table.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { ArrowDown, ArrowUp, ArrowUpDown, Eye, Pencil } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import Pagination from '@/components/common/pagination';
+import Loading from '@/components/common/loading';
+import { useProjects } from '@/hooks/use-projects';
+import {
+  Project,
+  ProjectStatus,
+  projectStatusColors,
+  projectStatusLabels,
+} from '@/types/project';
+
+type SortKey = 'name' | 'status' | 'start_date' | 'created_at' | 'profit_rate';
+
+const sortableColumns: { key: SortKey; label: string }[] = [
+  { key: 'name', label: 'プロジェクト名' },
+  { key: 'status', label: 'ステータス' },
+  { key: 'start_date', label: '期間' },
+  { key: 'profit_rate', label: '利益率' },
+];
+
+const PER_PAGE = 10;
+
+function formatPeriod(project: Project): string {
+  if (!project.start_date && !project.end_date) return '-';
+  return `${project.start_date ?? ''} 〜 ${project.end_date ?? ''}`;
+}
+
+function formatBudget(project: Project): string {
+  if (project.budget_amount == null) return '-';
+  return `¥${project.budget_amount.toLocaleString()}`;
+}
+
+export function ProjectTable() {
+  const [page, setPage] = useState(1);
+  const [status, setStatus] = useState<'all' | ProjectStatus>('all');
+  const [sort, setSort] = useState<SortKey>('created_at');
+  const [order, setOrder] = useState<'asc' | 'desc'>('desc');
+
+  const { data, isLoading, isError, error } = useProjects({
+    page,
+    per_page: PER_PAGE,
+    status: status === 'all' ? undefined : status,
+    sort,
+    order,
+  });
+
+  const toggleSort = (key: SortKey) => {
+    if (sort === key) {
+      setOrder(order === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSort(key);
+      setOrder(key === 'name' ? 'asc' : 'desc');
+    }
+    setPage(1);
+  };
+
+  const sortIcon = (key: SortKey) => {
+    if (sort !== key) return <ArrowUpDown className="ml-1 h-3 w-3" />;
+    return order === 'asc' ? (
+      <ArrowUp className="ml-1 h-3 w-3" />
+    ) : (
+      <ArrowDown className="ml-1 h-3 w-3" />
+    );
+  };
+
+  if (isError) {
+    return (
+      <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-800">
+        プロジェクトの取得に失敗しました: {error instanceof Error ? error.message : ''}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* ステータスフィルタ */}
+      <div className="flex items-center justify-between">
+        <Select
+          value={status}
+          onValueChange={(value) => {
+            setStatus(value as 'all' | ProjectStatus);
+            setPage(1);
+          }}
+        >
+          <SelectTrigger className="w-44">
+            <SelectValue placeholder="ステータスで絞り込み" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">すべて</SelectItem>
+            {(Object.keys(projectStatusLabels) as ProjectStatus[]).map((value) => (
+              <SelectItem key={value} value={value}>
+                {projectStatusLabels[value]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        {data && (
+          <span className="text-sm text-muted-foreground">全{data.pagination.total}件</span>
+        )}
+      </div>
+
+      {isLoading ? (
+        <Loading />
+      ) : (
+        <>
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  {sortableColumns.map(({ key, label }) => (
+                    <TableHead key={key}>
+                      <button
+                        type="button"
+                        className="flex items-center font-medium hover:text-foreground"
+                        onClick={() => toggleSort(key)}
+                      >
+                        {label}
+                        {sortIcon(key)}
+                      </button>
+                    </TableHead>
+                  ))}
+                  <TableHead>予算</TableHead>
+                  <TableHead className="text-right">操作</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {data?.projects.length ? (
+                  data.projects.map((project) => (
+                    <TableRow key={project.id}>
+                      <TableCell className="font-medium">
+                        <Link href={`/projects/${project.id}`} className="hover:underline">
+                          {project.name}
+                        </Link>
+                      </TableCell>
+                      <TableCell>
+                        <Badge className={projectStatusColors[project.status]}>
+                          {projectStatusLabels[project.status]}
+                        </Badge>
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {formatPeriod(project)}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">-</TableCell>
+                      <TableCell>{formatBudget(project)}</TableCell>
+                      <TableCell className="text-right">
+                        <div className="flex justify-end gap-1">
+                          <Button variant="ghost" size="sm" asChild>
+                            <Link href={`/projects/${project.id}`}>
+                              <Eye className="h-4 w-4" />
+                              <span className="sr-only">詳細</span>
+                            </Link>
+                          </Button>
+                          <Button variant="ghost" size="sm" asChild>
+                            <Link href={`/projects/${project.id}?edit=1`}>
+                              <Pencil className="h-4 w-4" />
+                              <span className="sr-only">編集</span>
+                            </Link>
+                          </Button>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell colSpan={6} className="h-24 text-center text-muted-foreground">
+                      プロジェクトがありません
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+
+          {data && data.pagination.total_pages > 1 && (
+            <Pagination
+              currentPage={page}
+              totalPages={data.pagination.total_pages}
+              onPageChange={setPage}
+            />
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/components/ui/table.tsx
+++ b/frontend/components/ui/table.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-auto">
+      <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    </div>
+  )
+);
+Table.displayName = 'Table';
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+));
+TableHeader.displayName = 'TableHeader';
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+));
+TableBody.displayName = 'TableBody';
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)}
+    {...props}
+  />
+));
+TableFooter.displayName = 'TableFooter';
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+        className
+      )}
+      {...props}
+    />
+  )
+);
+TableRow.displayName = 'TableRow';
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+      className
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = 'TableHead';
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
+    {...props}
+  />
+));
+TableCell.displayName = 'TableCell';
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption ref={ref} className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
+));
+TableCaption.displayName = 'TableCaption';
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };


### PR DESCRIPTION
## 概要

Issue #43 (T168) の実装。ダッシュボード用の拡張プロジェクトテーブルを追加。

## 変更内容

- `frontend/components/ui/table.tsx`: shadcn/ui標準のTableプリミティブ（リポジトリ未導入だったため追加）
- `frontend/components/dashboard/project-table.tsx`: `ProjectTable`
  - ステータス別フィルタ（Select、全件/計画中/進行中/完了/保留中）
  - ソート可能ヘッダー: プロジェクト名・ステータス・期間・**利益率**（#125 の `sort=profit_rate` をサーバーサイドで利用）
  - クイックアクション: 詳細表示・編集リンク
  - ページネーション（既存の共通コンポーネント再利用）
  - ローディング・エラー・空状態の表示

## 既知の制約

利益率カラムの**値表示**は「-」。プロジェクト一覧APIのレスポンスに利益率が含まれないため（ソートは機能する）。一覧レスポンスへの `profit_rate` 追加はバックエンド側の小さな拡張として別途対応可能。

## 検証

- `npm run type-check` → パス
- ダッシュボードページへの組み込みは #44 (T169) で実施

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)