### PR TITLE
feat(dashboard): ダッシュボードページ実装 (T169)

### DIFF
--- a/frontend/app/(dashboard)/dashboard/page.tsx
+++ b/frontend/app/(dashboard)/dashboard/page.tsx
@@ -1,49 +1,70 @@
 'use client';
 
-import { useCurrentUser } from '@/hooks/use-auth';
+import {
+  Briefcase,
+  CheckCircle2,
+  DollarSign,
+  Percent,
+  PlayCircle,
+  TrendingUp,
+} from 'lucide-react';
+
 import Loading from '@/components/common/loading';
+import { KpiCard } from '@/components/dashboard/kpi-card';
+import { ProjectTable } from '@/components/dashboard/project-table';
+import { useCurrentUser } from '@/hooks/use-auth';
+import { useDashboard } from '@/hooks/use-dashboard';
+import { formatCurrency } from '@/types/budget';
 
 export default function DashboardPage() {
-  const { data: user, isLoading } = useCurrentUser();
+  const { data: user, isLoading: isUserLoading } = useCurrentUser();
+  const { data: dashboard, isLoading: isDashboardLoading, isError, error } = useDashboard();
 
-  if (isLoading) {
+  if (isUserLoading || isDashboardLoading) {
     return <Loading />;
   }
 
   return (
-    <div>
-      <h1 className="text-3xl font-bold text-gray-900 mb-6">ダッシュボード</h1>
-      
-      <div className="bg-white p-6 rounded-lg shadow mb-6">
-        <h2 className="text-xl font-semibold mb-4">ようこそ、{user?.name}さん</h2>
-        <p className="text-gray-600">
-          プロジェクト予算管理システムにログインしています。
-        </p>
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">ダッシュボード</h1>
+        {user && <p className="text-muted-foreground mt-1">ようこそ、{user.name}さん</p>}
       </div>
 
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-6">
-        <div className="bg-white p-6 rounded-lg shadow">
-          <div className="text-sm text-gray-600 mb-2">総プロジェクト数</div>
-          <div className="text-3xl font-bold">0</div>
+      {isError && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-4 text-red-800">
+          ダッシュボードの取得に失敗しました: {error instanceof Error ? error.message : ''}
         </div>
-        
-        <div className="bg-white p-6 rounded-lg shadow">
-          <div className="text-sm text-gray-600 mb-2">進行中</div>
-          <div className="text-3xl font-bold">0</div>
-        </div>
-        
-        <div className="bg-white p-6 rounded-lg shadow">
-          <div className="text-sm text-gray-600 mb-2">完了</div>
-          <div className="text-3xl font-bold">0</div>
-        </div>
-      </div>
+      )}
 
-      <div className="bg-white p-6 rounded-lg shadow">
-        <h2 className="text-xl font-semibold mb-4">最近のプロジェクト</h2>
-        <p className="text-gray-500 text-center py-8">
-          プロジェクトがまだありません
-        </p>
-      </div>
+      {dashboard && (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+          <KpiCard title="総プロジェクト数" value={dashboard.total_projects} icon={Briefcase} />
+          <KpiCard title="進行中" value={dashboard.active_projects} icon={PlayCircle} />
+          <KpiCard title="完了" value={dashboard.completed_projects} icon={CheckCircle2} />
+          <KpiCard
+            title="総売上"
+            value={formatCurrency(dashboard.total_revenue)}
+            icon={DollarSign}
+          />
+          <KpiCard
+            title="総利益"
+            value={formatCurrency(dashboard.total_profit)}
+            icon={TrendingUp}
+            valueClassName={dashboard.total_profit < 0 ? 'text-red-600' : 'text-green-600'}
+          />
+          <KpiCard
+            title="平均利益率"
+            value={`${dashboard.average_profit_rate.toFixed(1)}%`}
+            icon={Percent}
+          />
+        </div>
+      )}
+
+      <section className="space-y-3">
+        <h2 className="text-xl font-semibold">プロジェクト一覧</h2>
+        <ProjectTable />
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## 概要

Issue #44 (T169) の実装。ハードコードされた0表示のプレースホルダーだったダッシュボードページを、Phase 7 で実装したAPI・コンポーネント群による実データ表示に置き換え。

## 変更内容

`frontend/app/(dashboard)/dashboard/page.tsx`:

- `useDashboard`（#128）でKPIサマリーを取得
- `KpiCard`（#129）でKPI6種を表示
  - 総プロジェクト数 / 進行中 / 完了 / 総売上 / 総利益（黒字緑・赤字赤の色分け） / 平均利益率
- `ProjectTable`（#130）でステータスフィルタ・ソート付きプロジェクト一覧を表示
- ローディング・エラー状態のハンドリング

## 検証

- `npm run type-check` → パス

これでPhase 7（User Story 4 - ダッシュボード）の実装タスクは、E2Eテスト #45 (T170) を残すのみ。

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)