### PR TITLE
test(dashboard): ダッシュボードE2Eテスト (T170)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,8 @@ Thumbs.db
 # Production
 /frontend/.env.production
 /backend/.env.production
+
+# Playwright
+frontend/test-results/
+frontend/playwright-report/
+frontend/next-env.d.ts

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "zustand": "^4.5.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@types/node": "^20.19.20",
         "@types/react": "^18.3.26",
         "@types/react-dom": "^18.3.7",
@@ -1336,6 +1337,22 @@
         "node": ">=14"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
@@ -2265,14 +2282,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.26",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.26.tgz",
       "integrity": "sha512-RFA/bURkcKzx/X9oumPG9Vp3D3JUgus/d0b67KB0t5S/raciymilkOa66olh78MUI92QLbEJevO7rvqU/kjwKA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -2283,7 +2300,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -6547,6 +6564,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -32,6 +33,7 @@
     "zustand": "^4.5.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/node": "^20.19.20",
     "@types/react": "^18.3.26",
     "@types/react-dom": "^18.3.7",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000/login',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});

--- a/frontend/tests/e2e/dashboard.spec.ts
+++ b/frontend/tests/e2e/dashboard.spec.ts
@@ -1,0 +1,149 @@
+import { test, expect, Page } from '@playwright/test';
+
+// APIをルートモックしたダッシュボードのE2Eテスト (T170)
+// バックエンド・DBなしでフロントエンドの動作を検証する
+
+const user = {
+  id: '11111111-1111-1111-1111-111111111111',
+  email: 'demo@example.com',
+  name: 'デモユーザー',
+  role: 'member',
+};
+
+const now = '2026-06-01T00:00:00Z';
+
+const projects = [
+  {
+    id: 'aaaaaaaa-0000-0000-0000-000000000001',
+    user_id: user.id,
+    name: 'ECサイトリニューアル',
+    status: 'in_progress',
+    start_date: '2026-04-01',
+    end_date: '2026-08-31',
+    budget_amount: 5000000,
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: 'aaaaaaaa-0000-0000-0000-000000000002',
+    user_id: user.id,
+    name: '社内システム保守',
+    status: 'completed',
+    created_at: now,
+    updated_at: now,
+  },
+  {
+    id: 'aaaaaaaa-0000-0000-0000-000000000003',
+    user_id: user.id,
+    name: 'モバイルアプリ開発',
+    status: 'planning',
+    created_at: now,
+    updated_at: now,
+  },
+];
+
+const dashboard = {
+  total_projects: 3,
+  active_projects: 1,
+  completed_projects: 1,
+  total_revenue: 3000000,
+  total_profit: 1400000,
+  average_profit_rate: 45.0,
+  recent_projects: projects,
+};
+
+async function mockApi(page: Page) {
+  await page.route('**/api/v1/auth/me', (route) =>
+    route.fulfill({ json: { success: true, data: user } })
+  );
+  await page.route('**/api/v1/dashboard', (route) =>
+    route.fulfill({ json: { success: true, data: dashboard } })
+  );
+  await page.route('**/api/v1/projects**', (route) => {
+    const url = new URL(route.request().url());
+    const status = url.searchParams.get('status');
+    const filtered = status ? projects.filter((p) => p.status === status) : projects;
+    return route.fulfill({
+      json: {
+        success: true,
+        data: {
+          projects: filtered,
+          pagination: { page: 1, per_page: 10, total: filtered.length, total_pages: 1 },
+        },
+      },
+    });
+  });
+}
+
+// Next.jsミドルウェアはCookie、APIクライアントとZustandストアは
+// localStorageを参照するため両方を設定する
+async function authenticate(page: Page) {
+  await page.context().addCookies([
+    { name: 'token', value: 'e2e-test-token', url: 'http://localhost:3000' },
+  ]);
+  await page.addInitScript(
+    ([u]) => {
+      localStorage.setItem('token', 'e2e-test-token');
+      localStorage.setItem(
+        'auth-storage',
+        JSON.stringify({ state: { user: u, isAuthenticated: true }, version: 0 })
+      );
+    },
+    [user]
+  );
+}
+
+test.describe('ダッシュボード', () => {
+  test('KPIカードにサマリーが表示される', async ({ page }) => {
+    await authenticate(page);
+    await mockApi(page);
+
+    await page.goto('/dashboard');
+
+    await expect(page.getByRole('heading', { name: 'ダッシュボード' })).toBeVisible();
+    await expect(page.getByText('ようこそ、デモユーザーさん')).toBeVisible();
+
+    await expect(page.getByText('総プロジェクト数')).toBeVisible();
+    await expect(page.getByText('総売上')).toBeVisible();
+    await expect(page.getByText('総利益')).toBeVisible();
+    await expect(page.getByText('平均利益率')).toBeVisible();
+    await expect(page.getByText('45.0%')).toBeVisible();
+    // 通貨表示（記号はロケール依存のため数値部分のみ検証）
+    await expect(page.getByText(/3,000,000/)).toBeVisible();
+    await expect(page.getByText(/1,400,000/)).toBeVisible();
+  });
+
+  test('プロジェクト一覧テーブルが表示される', async ({ page }) => {
+    await authenticate(page);
+    await mockApi(page);
+
+    await page.goto('/dashboard');
+
+    await expect(page.getByRole('heading', { name: 'プロジェクト一覧' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'ECサイトリニューアル' })).toBeVisible();
+    await expect(page.getByRole('link', { name: '社内システム保守' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'モバイルアプリ開発' })).toBeVisible();
+    await expect(page.getByText('全3件')).toBeVisible();
+  });
+
+  test('ステータスフィルタで絞り込める', async ({ page }) => {
+    await authenticate(page);
+    await mockApi(page);
+
+    await page.goto('/dashboard');
+    await expect(page.getByRole('link', { name: 'ECサイトリニューアル' })).toBeVisible();
+
+    // ステータスフィルタで「進行中」を選択
+    await page.getByRole('combobox').click();
+    await page.getByRole('option', { name: '進行中' }).click();
+
+    await expect(page.getByRole('link', { name: 'ECサイトリニューアル' })).toBeVisible();
+    await expect(page.getByRole('link', { name: '社内システム保守' })).not.toBeVisible();
+    await expect(page.getByText('全1件')).toBeVisible();
+  });
+
+  test('未認証アクセスはログインページへリダイレクトされる', async ({ page }) => {
+    await page.goto('/dashboard');
+    await expect(page).toHaveURL(/\/login/);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #45 (T170) の実装。リポジトリ初のE2Eテスト環境（Playwright）を導入し、ダッシュボードのE2Eテストを追加。**これでPhase 7（User Story 4 - ダッシュボード）は全タスク完了。**

## 変更内容

- `frontend/playwright.config.ts`: Playwright設定（chromium、`npm run dev` 自動起動、CIでretry/traceあり）
- `frontend/tests/e2e/dashboard.spec.ts`: E2Eテスト4ケース
  - KPIカード表示（件数・売上・利益・平均利益率）
  - プロジェクト一覧テーブル表示
  - ステータスフィルタでの絞り込み（Radix Selectの操作）
  - 未認証アクセスの `/login` リダイレクト（Next.jsミドルウェア検証）
- `package.json`: `@playwright/test` devDependency と `npm run test:e2e` スクリプト追加
- `.gitignore`: Playwright成果物を除外

## 設計メモ

バックエンド・DBを起動せずに実行できるよう **`page.route` によるAPIモック方式**を採用（認証はNextミドルウェア用Cookie + APIクライアント用localStorageの両方を設定）。実APIとの結合は #127 のバックエンド統合テストでカバー済み。

## テスト結果（実行済み）

```
npx playwright test
  4 passed (4.8s)
```

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)