### PR TITLE
feat(analytics): AnalyticsService実装 (T171)

### DIFF
--- a/backend/internal/dto/analytics_dto.go
+++ b/backend/internal/dto/analytics_dto.go
@@ -1,0 +1,72 @@
+package dto
+
+// PlanActualTaskData represents plan vs actual hours for a single task
+type PlanActualTaskData struct {
+	TaskName     string  `json:"task_name"`
+	PlannedHours float64 `json:"planned_hours"`
+	ActualHours  float64 `json:"actual_hours"`
+	Variance     float64 `json:"variance"`
+}
+
+// PlanActualResponse represents plan vs actual comparison data
+type PlanActualResponse struct {
+	Tasks []PlanActualTaskData `json:"tasks"`
+}
+
+// MemberCostData represents cost attributed to a member
+type MemberCostData struct {
+	MemberName string  `json:"member_name"`
+	Cost       float64 `json:"cost"`
+}
+
+// BudgetAnalyticsResponse represents budget analytics data
+type BudgetAnalyticsResponse struct {
+	Revenue       float64          `json:"revenue"`
+	TotalCost     float64          `json:"total_cost"`
+	CostBreakdown []MemberCostData `json:"cost_breakdown"`
+	Profit        float64          `json:"profit"`
+	ProfitRate    float64          `json:"profit_rate"`
+}
+
+// TrendDataPoint represents one bucket in a trend series
+type TrendDataPoint struct {
+	Date         string  `json:"date"`
+	PlannedHours float64 `json:"planned_hours"`
+	ActualHours  float64 `json:"actual_hours"`
+	Cost         float64 `json:"cost"`
+}
+
+// TrendResponse represents time-series trend data
+type TrendResponse struct {
+	Period     string           `json:"period"`
+	DataPoints []TrendDataPoint `json:"data_points"`
+}
+
+// TaskDistributionItem represents a task's share of actual hours
+type TaskDistributionItem struct {
+	TaskName    string  `json:"task_name"`
+	ActualHours float64 `json:"actual_hours"`
+	Percentage  float64 `json:"percentage"`
+}
+
+// TaskDistributionResponse represents actual hours distribution across tasks
+type TaskDistributionResponse struct {
+	Tasks []TaskDistributionItem `json:"tasks"`
+}
+
+// ProjectComparisonItem represents one project's KPIs for comparison
+type ProjectComparisonItem struct {
+	ProjectID    string  `json:"project_id"`
+	ProjectName  string  `json:"project_name"`
+	PlannedHours float64 `json:"planned_hours"`
+	ActualHours  float64 `json:"actual_hours"`
+	Revenue      float64 `json:"revenue"`
+	TotalCost    float64 `json:"total_cost"`
+	Profit       float64 `json:"profit"`
+	ProfitRate   float64 `json:"profit_rate"`
+}
+
+// ProjectsComparisonResponse represents cross-project comparison data
+type ProjectsComparisonResponse struct {
+	Projects []ProjectComparisonItem `json:"projects"`
+}

--- a/backend/internal/service/analytics_service.go
+++ b/backend/internal/service/analytics_service.go
@@ -1,0 +1,284 @@
+package service
+
+import (
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+
+	"github.com/your-org/project-budget-tracker/backend/internal/dto"
+	apperrors "github.com/your-org/project-budget-tracker/backend/internal/errors"
+	"github.com/your-org/project-budget-tracker/backend/internal/models"
+	"github.com/your-org/project-budget-tracker/backend/internal/repository"
+)
+
+// Trend periods supported by GetTrends
+const (
+	TrendPeriodDaily   = "daily"
+	TrendPeriodWeekly  = "weekly"
+	TrendPeriodMonthly = "monthly"
+)
+
+// AnalyticsService handles business logic for chart/analytics data
+type AnalyticsService struct {
+	db            *gorm.DB
+	timeEntryRepo *repository.TimeEntryRepository
+}
+
+// NewAnalyticsService creates a new AnalyticsService
+func NewAnalyticsService(db *gorm.DB) *AnalyticsService {
+	return &AnalyticsService{
+		db:            db,
+		timeEntryRepo: repository.NewTimeEntryRepository(db),
+	}
+}
+
+func (s *AnalyticsService) verifyProject(projectID uuid.UUID) error {
+	var project models.Project
+	if err := s.db.First(&project, "id = ?", projectID).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return apperrors.ErrNotFound("Project")
+		}
+		return apperrors.ErrDatabaseError(err)
+	}
+	return nil
+}
+
+// GetPlanActual returns planned vs actual hours per task
+func (s *AnalyticsService) GetPlanActual(projectID uuid.UUID) (*dto.PlanActualResponse, error) {
+	if err := s.verifyProject(projectID); err != nil {
+		return nil, err
+	}
+
+	var tasks []models.Task
+	if err := s.db.Where("project_id = ?", projectID).Order("created_at ASC").Find(&tasks).Error; err != nil {
+		return nil, apperrors.ErrDatabaseError(err)
+	}
+
+	response := &dto.PlanActualResponse{Tasks: make([]dto.PlanActualTaskData, len(tasks))}
+	for i, task := range tasks {
+		response.Tasks[i] = dto.PlanActualTaskData{
+			TaskName:     task.Name,
+			PlannedHours: task.PlannedHours,
+			ActualHours:  task.ActualHours,
+			Variance:     task.VarianceHours(),
+		}
+	}
+	return response, nil
+}
+
+// GetBudgetAnalytics returns revenue, cost breakdown by member, and profit
+func (s *AnalyticsService) GetBudgetAnalytics(projectID uuid.UUID) (*dto.BudgetAnalyticsResponse, error) {
+	if err := s.verifyProject(projectID); err != nil {
+		return nil, err
+	}
+
+	var revenue float64
+	var budget models.Budget
+	if err := s.db.First(&budget, "project_id = ?", projectID).Error; err == nil {
+		revenue = budget.Revenue
+	} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, apperrors.ErrDatabaseError(err)
+	}
+
+	summary, err := s.timeEntryRepo.GetSummaryByProject(projectID)
+	if err != nil {
+		return nil, apperrors.ErrDatabaseError(err)
+	}
+
+	memberSummaries, err := s.timeEntryRepo.GetSummaryByMember(projectID)
+	if err != nil {
+		return nil, apperrors.ErrDatabaseError(err)
+	}
+
+	breakdown := make([]dto.MemberCostData, len(memberSummaries))
+	for i, ms := range memberSummaries {
+		breakdown[i] = dto.MemberCostData{MemberName: ms.MemberName, Cost: ms.Cost}
+	}
+
+	profit := revenue - summary.TotalCost
+	profitRate := 0.0
+	if revenue > 0 {
+		profitRate = (profit / revenue) * 100
+	}
+
+	return &dto.BudgetAnalyticsResponse{
+		Revenue:       revenue,
+		TotalCost:     summary.TotalCost,
+		CostBreakdown: breakdown,
+		Profit:        profit,
+		ProfitRate:    profitRate,
+	}, nil
+}
+
+// GetTrends returns time-series data bucketed by the given period
+// (daily / weekly / monthly). Actual hours and cost come from time
+// entries; planned hours are attributed to the bucket containing the
+// task's start date.
+func (s *AnalyticsService) GetTrends(projectID uuid.UUID, period string) (*dto.TrendResponse, error) {
+	switch period {
+	case "":
+		period = TrendPeriodMonthly
+	case TrendPeriodDaily, TrendPeriodWeekly, TrendPeriodMonthly:
+	default:
+		return nil, apperrors.ErrValidationFailed("period must be one of: daily, weekly, monthly")
+	}
+
+	if err := s.verifyProject(projectID); err != nil {
+		return nil, err
+	}
+
+	entries, err := s.timeEntryRepo.GetByProjectID(projectID)
+	if err != nil {
+		return nil, apperrors.ErrDatabaseError(err)
+	}
+
+	var tasks []models.Task
+	if err := s.db.Where("project_id = ?", projectID).Find(&tasks).Error; err != nil {
+		return nil, apperrors.ErrDatabaseError(err)
+	}
+
+	buckets := map[string]*dto.TrendDataPoint{}
+	bucketOf := func(t time.Time) string { return bucketKey(t, period) }
+
+	for _, entry := range entries {
+		key := bucketOf(entry.WorkDate)
+		point, ok := buckets[key]
+		if !ok {
+			point = &dto.TrendDataPoint{Date: key}
+			buckets[key] = point
+		}
+		point.ActualHours += entry.Hours
+		point.Cost += entry.Cost()
+	}
+
+	for _, task := range tasks {
+		if task.StartDate == nil {
+			continue
+		}
+		key := bucketOf(*task.StartDate)
+		point, ok := buckets[key]
+		if !ok {
+			point = &dto.TrendDataPoint{Date: key}
+			buckets[key] = point
+		}
+		point.PlannedHours += task.PlannedHours
+	}
+
+	response := &dto.TrendResponse{Period: period, DataPoints: make([]dto.TrendDataPoint, 0, len(buckets))}
+	for _, point := range buckets {
+		response.DataPoints = append(response.DataPoints, *point)
+	}
+	sort.Slice(response.DataPoints, func(i, j int) bool {
+		return response.DataPoints[i].Date < response.DataPoints[j].Date
+	})
+	return response, nil
+}
+
+// bucketKey maps a date to its bucket label for the given period
+func bucketKey(t time.Time, period string) string {
+	switch period {
+	case TrendPeriodDaily:
+		return t.Format("2006-01-02")
+	case TrendPeriodWeekly:
+		// 週の開始日（月曜）の日付をバケットとして使用
+		weekday := int(t.Weekday())
+		if weekday == 0 {
+			weekday = 7
+		}
+		return t.AddDate(0, 0, -(weekday - 1)).Format("2006-01-02")
+	default: // monthly
+		return t.Format("2006-01")
+	}
+}
+
+// GetTaskDistribution returns each task's share of the project's actual hours
+func (s *AnalyticsService) GetTaskDistribution(projectID uuid.UUID) (*dto.TaskDistributionResponse, error) {
+	if err := s.verifyProject(projectID); err != nil {
+		return nil, err
+	}
+
+	var tasks []models.Task
+	if err := s.db.Where("project_id = ?", projectID).Order("actual_hours DESC").Find(&tasks).Error; err != nil {
+		return nil, apperrors.ErrDatabaseError(err)
+	}
+
+	var totalActual float64
+	for _, task := range tasks {
+		totalActual += task.ActualHours
+	}
+
+	response := &dto.TaskDistributionResponse{Tasks: make([]dto.TaskDistributionItem, len(tasks))}
+	for i, task := range tasks {
+		percentage := 0.0
+		if totalActual > 0 {
+			percentage = (task.ActualHours / totalActual) * 100
+		}
+		response.Tasks[i] = dto.TaskDistributionItem{
+			TaskName:    task.Name,
+			ActualHours: task.ActualHours,
+			Percentage:  percentage,
+		}
+	}
+	return response, nil
+}
+
+// GetProjectsComparison returns KPIs for all of the user's projects
+func (s *AnalyticsService) GetProjectsComparison(userIDStr string) (*dto.ProjectsComparisonResponse, error) {
+	userID, err := uuid.Parse(userIDStr)
+	if err != nil {
+		return nil, apperrors.ErrInvalidInput(err)
+	}
+
+	var projects []models.Project
+	if err := s.db.Where("user_id = ?", userID).Order("created_at ASC").Find(&projects).Error; err != nil {
+		return nil, apperrors.ErrDatabaseError(err)
+	}
+
+	response := &dto.ProjectsComparisonResponse{
+		Projects: make([]dto.ProjectComparisonItem, len(projects)),
+	}
+
+	for i, project := range projects {
+		item := dto.ProjectComparisonItem{
+			ProjectID:   project.ID.String(),
+			ProjectName: project.Name,
+		}
+
+		var hours struct {
+			PlannedHours float64
+			ActualHours  float64
+		}
+		if err := s.db.Model(&models.Task{}).
+			Where("project_id = ?", project.ID).
+			Select("COALESCE(SUM(planned_hours), 0) AS planned_hours, COALESCE(SUM(actual_hours), 0) AS actual_hours").
+			Scan(&hours).Error; err != nil {
+			return nil, apperrors.ErrDatabaseError(err)
+		}
+		item.PlannedHours = hours.PlannedHours
+		item.ActualHours = hours.ActualHours
+
+		summary, err := s.timeEntryRepo.GetSummaryByProject(project.ID)
+		if err != nil {
+			return nil, apperrors.ErrDatabaseError(err)
+		}
+		item.TotalCost = summary.TotalCost
+
+		var budget models.Budget
+		if err := s.db.First(&budget, "project_id = ?", project.ID).Error; err == nil {
+			item.Revenue = budget.Revenue
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, apperrors.ErrDatabaseError(err)
+		}
+
+		item.Profit = item.Revenue - item.TotalCost
+		if item.Revenue > 0 {
+			item.ProfitRate = (item.Profit / item.Revenue) * 100
+		}
+
+		response.Projects[i] = item
+	}
+	return response, nil
+}

--- a/backend/internal/service/analytics_service_test.go
+++ b/backend/internal/service/analytics_service_test.go
@@ -1,0 +1,237 @@
+package service_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/your-org/project-budget-tracker/backend/internal/models"
+	"github.com/your-org/project-budget-tracker/backend/internal/service"
+)
+
+func setupAnalyticsTestDB(t *testing.T) *gorm.DB {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// AutoMigrate cannot be used here: the models declare the PostgreSQL-only
+	// default uuid_generate_v4(), which sqlite rejects
+	ddl := []string{
+		`CREATE TABLE users (
+			id TEXT PRIMARY KEY, email TEXT NOT NULL, password_hash TEXT NOT NULL,
+			name TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member',
+			created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+		`CREATE TABLE projects (
+			id TEXT PRIMARY KEY, user_id TEXT NOT NULL, name TEXT NOT NULL,
+			description TEXT, status TEXT NOT NULL DEFAULT 'planning',
+			budget_amount REAL, start_date DATE, end_date DATE,
+			created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+		`CREATE TABLE tasks (
+			id TEXT PRIMARY KEY, project_id TEXT NOT NULL, assigned_to TEXT,
+			name TEXT NOT NULL, description TEXT,
+			planned_hours REAL DEFAULT 0, actual_hours REAL DEFAULT 0,
+			status TEXT NOT NULL DEFAULT 'todo', start_date DATE, end_date DATE,
+			created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+		`CREATE TABLE members (
+			id TEXT PRIMARY KEY, user_id TEXT, name TEXT NOT NULL, email TEXT NOT NULL,
+			role TEXT, hourly_rate REAL DEFAULT 0, department TEXT,
+			created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+		`CREATE TABLE time_entries (
+			id TEXT PRIMARY KEY, task_id TEXT NOT NULL, member_id TEXT NOT NULL,
+			user_id TEXT NOT NULL, work_date DATE NOT NULL, hours REAL NOT NULL,
+			hourly_rate_snapshot REAL, comment TEXT,
+			created_at DATETIME, updated_at DATETIME)`,
+		`CREATE TABLE budgets (
+			id TEXT PRIMARY KEY, project_id TEXT NOT NULL UNIQUE,
+			revenue REAL DEFAULT 0, total_cost REAL DEFAULT 0,
+			profit REAL DEFAULT 0, profit_rate REAL DEFAULT 0,
+			currency TEXT NOT NULL DEFAULT 'JPY',
+			created_at DATETIME, updated_at DATETIME)`,
+	}
+	for _, stmt := range ddl {
+		require.NoError(t, db.Exec(stmt).Error)
+	}
+	return db
+}
+
+type analyticsFixture struct {
+	db      *gorm.DB
+	svc     *service.AnalyticsService
+	user    *models.User
+	project *models.Project
+	member  *models.Member
+}
+
+func setupAnalyticsFixture(t *testing.T) *analyticsFixture {
+	db := setupAnalyticsTestDB(t)
+
+	user := &models.User{ID: uuid.New(), Email: "test@example.com", PasswordHash: "hash", Name: "Test", Role: "member"}
+	require.NoError(t, db.Create(user).Error)
+
+	project := &models.Project{ID: uuid.New(), UserID: user.ID, Name: "分析対象プロジェクト", Status: "in_progress"}
+	require.NoError(t, db.Create(project).Error)
+
+	member := &models.Member{ID: uuid.New(), Name: "メンバーA", Email: "a@example.com", HourlyRate: 5000}
+	require.NoError(t, db.Create(member).Error)
+
+	return &analyticsFixture{db: db, svc: service.NewAnalyticsService(db), user: user, project: project, member: member}
+}
+
+func (f *analyticsFixture) createTask(t *testing.T, name string, planned, actual float64, start *time.Time) *models.Task {
+	task := &models.Task{
+		ID: uuid.New(), ProjectID: f.project.ID, Name: name,
+		PlannedHours: planned, ActualHours: actual, Status: "in_progress", StartDate: start,
+	}
+	require.NoError(t, f.db.Create(task).Error)
+	return task
+}
+
+func (f *analyticsFixture) createEntry(t *testing.T, task *models.Task, workDate string, hours, rate float64) {
+	d, err := time.Parse("2006-01-02", workDate)
+	require.NoError(t, err)
+	entry := &models.TimeEntry{
+		ID: uuid.New(), TaskID: task.ID, MemberID: f.member.ID, UserID: f.user.ID,
+		WorkDate: d, Hours: hours, HourlyRateSnapshot: &rate,
+	}
+	require.NoError(t, f.db.Create(entry).Error)
+}
+
+func TestAnalyticsService_GetPlanActual(t *testing.T) {
+	f := setupAnalyticsFixture(t)
+	f.createTask(t, "設計", 40, 36, nil)
+	f.createTask(t, "実装", 80, 100, nil)
+
+	result, err := f.svc.GetPlanActual(f.project.ID)
+	require.NoError(t, err)
+	require.Len(t, result.Tasks, 2)
+	assert.Equal(t, "設計", result.Tasks[0].TaskName)
+	assert.Equal(t, -4.0, result.Tasks[0].Variance)
+	assert.Equal(t, 20.0, result.Tasks[1].Variance)
+
+	_, err = f.svc.GetPlanActual(uuid.New())
+	require.Error(t, err)
+}
+
+func TestAnalyticsService_GetBudgetAnalytics(t *testing.T) {
+	f := setupAnalyticsFixture(t)
+	task := f.createTask(t, "実装", 80, 0, nil)
+	f.createEntry(t, task, "2026-05-01", 10, 5000) // cost 50,000
+	f.createEntry(t, task, "2026-05-02", 10, 5000) // cost 50,000
+
+	budget := &models.Budget{ID: uuid.New(), ProjectID: f.project.ID, Revenue: 500000, Currency: "JPY"}
+	require.NoError(t, f.db.Create(budget).Error)
+
+	result, err := f.svc.GetBudgetAnalytics(f.project.ID)
+	require.NoError(t, err)
+	assert.Equal(t, 500000.0, result.Revenue)
+	assert.Equal(t, 100000.0, result.TotalCost)
+	assert.Equal(t, 400000.0, result.Profit)
+	assert.Equal(t, 80.0, result.ProfitRate)
+	require.Len(t, result.CostBreakdown, 1)
+	assert.Equal(t, "メンバーA", result.CostBreakdown[0].MemberName)
+	assert.Equal(t, 100000.0, result.CostBreakdown[0].Cost)
+}
+
+func TestAnalyticsService_GetTrends(t *testing.T) {
+	f := setupAnalyticsFixture(t)
+	start := time.Date(2026, 4, 10, 0, 0, 0, 0, time.UTC)
+	task := f.createTask(t, "実装", 100, 0, &start)
+	f.createEntry(t, task, "2026-04-15", 8, 5000)
+	f.createEntry(t, task, "2026-04-16", 4, 5000)
+	f.createEntry(t, task, "2026-05-01", 6, 5000)
+
+	t.Run("monthly: 月単位で集計される", func(t *testing.T) {
+		result, err := f.svc.GetTrends(f.project.ID, "")
+		require.NoError(t, err)
+		assert.Equal(t, "monthly", result.Period)
+		require.Len(t, result.DataPoints, 2)
+
+		april := result.DataPoints[0]
+		assert.Equal(t, "2026-04", april.Date)
+		assert.Equal(t, 12.0, april.ActualHours)
+		assert.Equal(t, 60000.0, april.Cost)
+		assert.Equal(t, 100.0, april.PlannedHours) // タスク開始日のバケットに計上
+
+		may := result.DataPoints[1]
+		assert.Equal(t, "2026-05", may.Date)
+		assert.Equal(t, 6.0, may.ActualHours)
+	})
+
+	t.Run("daily: 日単位で集計される", func(t *testing.T) {
+		result, err := f.svc.GetTrends(f.project.ID, "daily")
+		require.NoError(t, err)
+		require.Len(t, result.DataPoints, 4) // 工数3日 + タスク開始日
+		assert.Equal(t, "2026-04-10", result.DataPoints[0].Date)
+		assert.Equal(t, 100.0, result.DataPoints[0].PlannedHours)
+	})
+
+	t.Run("weekly: 週の開始日（月曜）に丸められる", func(t *testing.T) {
+		result, err := f.svc.GetTrends(f.project.ID, "weekly")
+		require.NoError(t, err)
+		// 2026-04-15(水)・16(木) は 2026-04-13(月) 週に入る
+		var found bool
+		for _, p := range result.DataPoints {
+			if p.Date == "2026-04-13" {
+				assert.Equal(t, 12.0, p.ActualHours)
+				found = true
+			}
+		}
+		assert.True(t, found)
+	})
+
+	t.Run("不正なperiodはエラー", func(t *testing.T) {
+		_, err := f.svc.GetTrends(f.project.ID, "yearly")
+		require.Error(t, err)
+	})
+}
+
+func TestAnalyticsService_GetTaskDistribution(t *testing.T) {
+	f := setupAnalyticsFixture(t)
+	f.createTask(t, "実装", 0, 75, nil)
+	f.createTask(t, "設計", 0, 25, nil)
+	f.createTask(t, "未着手", 0, 0, nil)
+
+	result, err := f.svc.GetTaskDistribution(f.project.ID)
+	require.NoError(t, err)
+	require.Len(t, result.Tasks, 3)
+	assert.Equal(t, "実装", result.Tasks[0].TaskName)
+	assert.Equal(t, 75.0, result.Tasks[0].Percentage)
+	assert.Equal(t, 25.0, result.Tasks[1].Percentage)
+	assert.Equal(t, 0.0, result.Tasks[2].Percentage)
+}
+
+func TestAnalyticsService_GetProjectsComparison(t *testing.T) {
+	f := setupAnalyticsFixture(t)
+	task := f.createTask(t, "実装", 50, 40, nil)
+	f.createEntry(t, task, "2026-05-01", 20, 5000) // cost 100,000
+
+	budget := &models.Budget{ID: uuid.New(), ProjectID: f.project.ID, Revenue: 300000, Currency: "JPY"}
+	require.NoError(t, f.db.Create(budget).Error)
+
+	// 収支未登録の2つ目のプロジェクト
+	project2 := &models.Project{ID: uuid.New(), UserID: f.user.ID, Name: "2つ目", Status: "planning"}
+	require.NoError(t, f.db.Create(project2).Error)
+
+	result, err := f.svc.GetProjectsComparison(f.user.ID.String())
+	require.NoError(t, err)
+	require.Len(t, result.Projects, 2)
+
+	first := result.Projects[0]
+	assert.Equal(t, "分析対象プロジェクト", first.ProjectName)
+	assert.Equal(t, 50.0, first.PlannedHours)
+	assert.Equal(t, 40.0, first.ActualHours)
+	assert.Equal(t, 300000.0, first.Revenue)
+	assert.Equal(t, 100000.0, first.TotalCost)
+	assert.Equal(t, 200000.0, first.Profit)
+
+	second := result.Projects[1]
+	assert.Equal(t, 0.0, second.Revenue)
+	assert.Equal(t, 0.0, second.Profit)
+
+	_, err = f.svc.GetProjectsComparison("not-a-uuid")
+	require.Error(t, err)
+}


### PR DESCRIPTION
## 概要

Issue #46 (T171) の実装。Phase 8（グラフ可視化）のバックエンド集計ロジックを追加。

## 変更内容

- `backend/internal/dto/analytics_dto.go`: OpenAPI契約（PlanActualData / BudgetAnalytics / TrendData）準拠のDTO群
- `backend/internal/service/analytics_service.go`: `AnalyticsService`
  - **GetPlanActual**: タスク別の予定・実績・差異
  - **GetBudgetAnalytics**: 売上、TimeEntry集計による総コスト、メンバー別コスト内訳、利益・利益率
  - **GetTrends**: daily / weekly（月曜開始）/ monthly のバケット集計。実績工数・コストはTimeEntryから、予定工数はタスク開始日のバケットに計上。**DB方言に依存しないようGo側でグルーピング**（本番Postgres・テストsqliteの両対応）
  - **GetTaskDistribution**: タスク別工数割合（合計0時は0%）
  - **GetProjectsComparison**: ユーザーの全プロジェクトのKPI比較（予実工数・売上・コスト・利益）
- 単体テスト5本（既存リポジトリ `GetSummaryByProject` / `GetSummaryByMember` の集計も間接検証）

## テスト

```
go test ./internal/service/  → ok（Analytics 5本 + 既存Dashboard分すべてパス）
go build / go vet / gofmt    → クリーン
```

ハンドラーとルーティングは #47 (T172) 以降で実装。

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)