### PR TITLE
feat(analytics): AnalyticsHandler実装 (T172)

### DIFF
--- a/backend/internal/handler/analytics_handler.go
+++ b/backend/internal/handler/analytics_handler.go
@@ -1,0 +1,107 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+
+	"github.com/your-org/project-budget-tracker/backend/internal/dto"
+	apperrors "github.com/your-org/project-budget-tracker/backend/internal/errors"
+	"github.com/your-org/project-budget-tracker/backend/internal/service"
+)
+
+// AnalyticsHandler handles HTTP requests for chart/analytics data
+type AnalyticsHandler struct {
+	analyticsService *service.AnalyticsService
+}
+
+// NewAnalyticsHandler creates a new AnalyticsHandler
+func NewAnalyticsHandler(analyticsService *service.AnalyticsService) *AnalyticsHandler {
+	return &AnalyticsHandler{analyticsService: analyticsService}
+}
+
+func (h *AnalyticsHandler) projectID(c echo.Context) (uuid.UUID, bool) {
+	projectID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		return uuid.Nil, false
+	}
+	return projectID, true
+}
+
+func handleAnalyticsError(c echo.Context, err error) error {
+	if appErr, ok := err.(*apperrors.AppError); ok {
+		return c.JSON(appErr.StatusCode, dto.ErrorResponse(appErr.Code, appErr.Message, nil))
+	}
+	return c.JSON(http.StatusInternalServerError, dto.ErrorResponse("INTERNAL_ERROR", "An internal error occurred", nil))
+}
+
+// GetPlanActual handles GET /api/v1/projects/:id/analytics/plan-actual
+func (h *AnalyticsHandler) GetPlanActual(c echo.Context) error {
+	projectID, ok := h.projectID(c)
+	if !ok {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse("INVALID_ID", "Invalid project ID", nil))
+	}
+
+	result, err := h.analyticsService.GetPlanActual(projectID)
+	if err != nil {
+		return handleAnalyticsError(c, err)
+	}
+	return c.JSON(http.StatusOK, dto.SuccessResponse(result))
+}
+
+// GetBudgetAnalytics handles GET /api/v1/projects/:id/analytics/budget
+func (h *AnalyticsHandler) GetBudgetAnalytics(c echo.Context) error {
+	projectID, ok := h.projectID(c)
+	if !ok {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse("INVALID_ID", "Invalid project ID", nil))
+	}
+
+	result, err := h.analyticsService.GetBudgetAnalytics(projectID)
+	if err != nil {
+		return handleAnalyticsError(c, err)
+	}
+	return c.JSON(http.StatusOK, dto.SuccessResponse(result))
+}
+
+// GetTrends handles GET /api/v1/projects/:id/analytics/trends?period=daily|weekly|monthly
+func (h *AnalyticsHandler) GetTrends(c echo.Context) error {
+	projectID, ok := h.projectID(c)
+	if !ok {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse("INVALID_ID", "Invalid project ID", nil))
+	}
+
+	result, err := h.analyticsService.GetTrends(projectID, c.QueryParam("period"))
+	if err != nil {
+		return handleAnalyticsError(c, err)
+	}
+	return c.JSON(http.StatusOK, dto.SuccessResponse(result))
+}
+
+// GetTaskDistribution handles GET /api/v1/projects/:id/analytics/task-distribution
+func (h *AnalyticsHandler) GetTaskDistribution(c echo.Context) error {
+	projectID, ok := h.projectID(c)
+	if !ok {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse("INVALID_ID", "Invalid project ID", nil))
+	}
+
+	result, err := h.analyticsService.GetTaskDistribution(projectID)
+	if err != nil {
+		return handleAnalyticsError(c, err)
+	}
+	return c.JSON(http.StatusOK, dto.SuccessResponse(result))
+}
+
+// GetProjectsComparison handles GET /api/v1/analytics/projects-comparison
+func (h *AnalyticsHandler) GetProjectsComparison(c echo.Context) error {
+	userID, ok := c.Get("user_id").(string)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, dto.ErrorResponse("UNAUTHORIZED", "User not authenticated", nil))
+	}
+
+	result, err := h.analyticsService.GetProjectsComparison(userID)
+	if err != nil {
+		return handleAnalyticsError(c, err)
+	}
+	return c.JSON(http.StatusOK, dto.SuccessResponse(result))
+}

--- a/backend/internal/handler/analytics_handler_test.go
+++ b/backend/internal/handler/analytics_handler_test.go
@@ -1,0 +1,168 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/your-org/project-budget-tracker/backend/internal/dto"
+	"github.com/your-org/project-budget-tracker/backend/internal/handler"
+	"github.com/your-org/project-budget-tracker/backend/internal/models"
+	"github.com/your-org/project-budget-tracker/backend/internal/service"
+)
+
+func setupAnalyticsHandlerTest(t *testing.T) (*handler.AnalyticsHandler, *gorm.DB, *models.Project) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	require.NoError(t, err)
+
+	// AutoMigrate cannot be used here: the models declare the PostgreSQL-only
+	// default uuid_generate_v4(), which sqlite rejects
+	ddl := []string{
+		`CREATE TABLE users (
+			id TEXT PRIMARY KEY, email TEXT NOT NULL, password_hash TEXT NOT NULL,
+			name TEXT NOT NULL, role TEXT NOT NULL DEFAULT 'member',
+			created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+		`CREATE TABLE projects (
+			id TEXT PRIMARY KEY, user_id TEXT NOT NULL, name TEXT NOT NULL,
+			description TEXT, status TEXT NOT NULL DEFAULT 'planning',
+			budget_amount REAL, start_date DATE, end_date DATE,
+			created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+		`CREATE TABLE tasks (
+			id TEXT PRIMARY KEY, project_id TEXT NOT NULL, assigned_to TEXT,
+			name TEXT NOT NULL, description TEXT,
+			planned_hours REAL DEFAULT 0, actual_hours REAL DEFAULT 0,
+			status TEXT NOT NULL DEFAULT 'todo', start_date DATE, end_date DATE,
+			created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+		`CREATE TABLE members (
+			id TEXT PRIMARY KEY, user_id TEXT, name TEXT NOT NULL, email TEXT NOT NULL,
+			role TEXT, hourly_rate REAL DEFAULT 0, department TEXT,
+			created_at DATETIME, updated_at DATETIME, deleted_at DATETIME)`,
+		`CREATE TABLE time_entries (
+			id TEXT PRIMARY KEY, task_id TEXT NOT NULL, member_id TEXT NOT NULL,
+			user_id TEXT NOT NULL, work_date DATE NOT NULL, hours REAL NOT NULL,
+			hourly_rate_snapshot REAL, comment TEXT,
+			created_at DATETIME, updated_at DATETIME)`,
+		`CREATE TABLE budgets (
+			id TEXT PRIMARY KEY, project_id TEXT NOT NULL UNIQUE,
+			revenue REAL DEFAULT 0, total_cost REAL DEFAULT 0,
+			profit REAL DEFAULT 0, profit_rate REAL DEFAULT 0,
+			currency TEXT NOT NULL DEFAULT 'JPY',
+			created_at DATETIME, updated_at DATETIME)`,
+	}
+	for _, stmt := range ddl {
+		require.NoError(t, db.Exec(stmt).Error)
+	}
+
+	user := &models.User{ID: uuid.New(), Email: "t@example.com", PasswordHash: "h", Name: "T", Role: "member"}
+	require.NoError(t, db.Create(user).Error)
+	project := &models.Project{ID: uuid.New(), UserID: user.ID, Name: "P", Status: "in_progress"}
+	require.NoError(t, db.Create(project).Error)
+	task := &models.Task{ID: uuid.New(), ProjectID: project.ID, Name: "実装", PlannedHours: 10, ActualHours: 12, Status: "in_progress"}
+	require.NoError(t, db.Create(task).Error)
+
+	return handler.NewAnalyticsHandler(service.NewAnalyticsService(db)), db, project
+}
+
+func analyticsRequest(e *echo.Echo, path, paramValue string) (echo.Context, *httptest.ResponseRecorder) {
+	req := httptest.NewRequest(http.MethodGet, path, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	if paramValue != "" {
+		c.SetParamNames("id")
+		c.SetParamValues(paramValue)
+	}
+	return c, rec
+}
+
+func TestAnalyticsHandler_GetPlanActual(t *testing.T) {
+	e := echo.New()
+	h, _, project := setupAnalyticsHandlerTest(t)
+
+	t.Run("正常系: タスク別予実が返る", func(t *testing.T) {
+		c, rec := analyticsRequest(e, "/api/v1/projects/x/analytics/plan-actual", project.ID.String())
+		require.NoError(t, h.GetPlanActual(c))
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp struct {
+			Success bool                   `json:"success"`
+			Data    dto.PlanActualResponse `json:"data"`
+		}
+		require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &resp))
+		require.Len(t, resp.Data.Tasks, 1)
+		assert.Equal(t, 2.0, resp.Data.Tasks[0].Variance)
+	})
+
+	t.Run("異常系: 不正なIDは400", func(t *testing.T) {
+		c, rec := analyticsRequest(e, "/api/v1/projects/x/analytics/plan-actual", "not-a-uuid")
+		require.NoError(t, h.GetPlanActual(c))
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("異常系: 存在しないプロジェクトは404", func(t *testing.T) {
+		c, rec := analyticsRequest(e, "/api/v1/projects/x/analytics/plan-actual", uuid.NewString())
+		require.NoError(t, h.GetPlanActual(c))
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+}
+
+func TestAnalyticsHandler_GetTrends(t *testing.T) {
+	e := echo.New()
+	h, _, project := setupAnalyticsHandlerTest(t)
+
+	t.Run("正常系: デフォルトはmonthly", func(t *testing.T) {
+		c, rec := analyticsRequest(e, "/api/v1/projects/x/analytics/trends", project.ID.String())
+		require.NoError(t, h.GetTrends(c))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), `"period":"monthly"`)
+	})
+
+	t.Run("異常系: 不正なperiodは400", func(t *testing.T) {
+		c, rec := analyticsRequest(e, "/api/v1/projects/x/analytics/trends?period=yearly", project.ID.String())
+		require.NoError(t, h.GetTrends(c))
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+}
+
+func TestAnalyticsHandler_GetBudgetAnalyticsAndDistribution(t *testing.T) {
+	e := echo.New()
+	h, _, project := setupAnalyticsHandlerTest(t)
+
+	c, rec := analyticsRequest(e, "/api/v1/projects/x/analytics/budget", project.ID.String())
+	require.NoError(t, h.GetBudgetAnalytics(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	c, rec = analyticsRequest(e, "/api/v1/projects/x/analytics/task-distribution", project.ID.String())
+	require.NoError(t, h.GetTaskDistribution(c))
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"percentage":100`)
+}
+
+func TestAnalyticsHandler_GetProjectsComparison(t *testing.T) {
+	e := echo.New()
+	h, db, project := setupAnalyticsHandlerTest(t)
+
+	var owner models.Project
+	require.NoError(t, db.First(&owner, "id = ?", project.ID).Error)
+
+	t.Run("正常系: ユーザーのプロジェクト比較が返る", func(t *testing.T) {
+		c, rec := analyticsRequest(e, "/api/v1/analytics/projects-comparison", "")
+		c.Set("user_id", owner.UserID.String())
+		require.NoError(t, h.GetProjectsComparison(c))
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Contains(t, rec.Body.String(), project.Name)
+	})
+
+	t.Run("異常系: 認証コンテキストなしは401", func(t *testing.T) {
+		c, rec := analyticsRequest(e, "/api/v1/analytics/projects-comparison", "")
+		require.NoError(t, h.GetProjectsComparison(c))
+		assert.Equal(t, http.StatusUnauthorized, rec.Code)
+	})
+}


### PR DESCRIPTION
## 概要

Issue #47 (T172) の実装。#133 の `AnalyticsService` をHTTPに公開するハンドラー層を追加。

## 変更内容

- `backend/internal/handler/analytics_handler.go`: `AnalyticsHandler`
  - `GetPlanActual` / `GetBudgetAnalytics` / `GetTrends`（period検証は400） / `GetTaskDistribution`: プロジェクトIDのパース（不正は400、存在しないプロジェクトは404）
  - `GetProjectsComparison`: 認証コンテキストの `user_id`（string）を使用、未設定は401
- 単体テスト4本（200 / 400 / 404 / 401 のステータスとレスポンス内容）

## テスト

```
go test ./internal/handler/  → ok
go build / go vet / gofmt    → クリーン
```

ルーティング登録は #48〜#52 (T173〜T177) で実施。

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)