### PR TITLE
feat(analytics): 分析APIルート登録 (T173〜T177)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -50,6 +50,7 @@ func main() {
 	memberService := service.NewMemberService(database.GetDB())
 	budgetService := service.NewBudgetService(database.GetDB())
 	dashboardService := service.NewDashboardService(database.GetDB())
+	analyticsService := service.NewAnalyticsService(database.GetDB())
 
 	// Initialize handlers
 	authHandler := handler.NewAuthHandler(authService)
@@ -58,6 +59,7 @@ func main() {
 	memberHandler := handler.NewMemberHandler(memberService)
 	budgetHandler := handler.NewBudgetHandler(budgetService)
 	dashboardHandler := handler.NewDashboardHandler(dashboardService)
+	analyticsHandler := handler.NewAnalyticsHandler(analyticsService)
 
 	// API v1 routes
 	v1 := e.Group("/api/v1")
@@ -100,6 +102,13 @@ func main() {
 
 	// Dashboard routes
 	protected.GET("/dashboard", dashboardHandler.GetDashboard)
+
+	// Analytics routes
+	protected.GET("/projects/:id/analytics/plan-actual", analyticsHandler.GetPlanActual)
+	protected.GET("/projects/:id/analytics/budget", analyticsHandler.GetBudgetAnalytics)
+	protected.GET("/projects/:id/analytics/trends", analyticsHandler.GetTrends)
+	protected.GET("/projects/:id/analytics/task-distribution", analyticsHandler.GetTaskDistribution)
+	protected.GET("/analytics/projects-comparison", analyticsHandler.GetProjectsComparison)
 
 	// Budget routes
 	protected.GET("/projects/:id/budget", budgetHandler.GetBudget)


### PR DESCRIPTION
## 概要

Issues #48〜#52 (T173〜T177) の実装。#133（Service）・#134（Handler）で実装済みの分析APIをルーターに登録して公開。

5つのIssueはいずれも同一箇所（`main.go` のルート登録）への1行追加のため、個別PRにするとリベース競合の連鎖になることから**1つのPRにまとめて対応**。

## 登録ルート（すべて認証必須）

| ルート | Issue/Task |
|---|---|
| `GET /api/v1/projects/:id/analytics/plan-actual` | #48 (T173) 予実比較 |
| `GET /api/v1/projects/:id/analytics/budget` | #49 (T174) 収支分析 |
| `GET /api/v1/projects/:id/analytics/trends?period=` | #50 (T175) 月次推移 |
| `GET /api/v1/projects/:id/analytics/task-distribution` | #51 (T176) タスク別工数割合 |
| `GET /api/v1/analytics/projects-comparison` | #52 (T177) 複数プロジェクト比較 |

## テスト

- `go build / go vet / gofmt` クリーン
- 各エンドポイントのロジックは #133 / #134 の単体テストでカバー済み。API統合テストは #53 (T178) で追加予定

Closes #48
Closes #49
Closes #50
Closes #51
Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)