### PR TITLE
feat(charts): Rechartsセットアップと共通スタイル設定 (T179)

### DIFF
--- a/frontend/components/charts/chart-container.tsx
+++ b/frontend/components/charts/chart-container.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { ResponsiveContainer } from 'recharts';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import Loading from '@/components/common/loading';
+import { chartDefaults } from '@/components/charts/chart-theme';
+
+interface ChartContainerProps {
+  /** グラフのタイトル */
+  title: string;
+  /** データ取得中の表示制御 */
+  isLoading?: boolean;
+  /** エラーメッセージ（指定時はグラフの代わりに表示） */
+  errorMessage?: string;
+  /** データが空のときのメッセージ */
+  emptyMessage?: string;
+  /** データが空かどうか */
+  isEmpty?: boolean;
+  /** グラフの高さ(px) */
+  height?: number;
+  /** Rechartsのチャート要素 */
+  children: ReactNode;
+}
+
+/**
+ * グラフ共通のラッパー (T179)
+ * Card + タイトル + ResponsiveContainer とローディング・エラー・
+ * 空状態の表示を統一する
+ */
+export function ChartContainer({
+  title,
+  isLoading = false,
+  errorMessage,
+  emptyMessage = 'データがありません',
+  isEmpty = false,
+  height = chartDefaults.height,
+  children,
+}: ChartContainerProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base font-semibold">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div style={{ height }} className="flex items-center justify-center">
+            <Loading />
+          </div>
+        ) : errorMessage ? (
+          <div
+            style={{ height }}
+            className="flex items-center justify-center rounded-md border border-red-200 bg-red-50 px-4 text-sm text-red-800"
+          >
+            {errorMessage}
+          </div>
+        ) : isEmpty ? (
+          <div
+            style={{ height }}
+            className="flex items-center justify-center text-sm text-muted-foreground"
+          >
+            {emptyMessage}
+          </div>
+        ) : (
+          <ResponsiveContainer width="100%" height={height}>
+            {children as React.ReactElement}
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/components/charts/chart-theme.ts
+++ b/frontend/components/charts/chart-theme.ts
@@ -1,0 +1,45 @@
+// グラフ共通のカラーテーマとフォーマッタ (T179)
+// 全チャートコンポーネントはここから色・書式を参照して統一感を保つ
+
+export const chartColors = {
+  planned: '#94a3b8', // slate-400: 予定
+  actual: '#3b82f6', // blue-500: 実績
+  revenue: '#3b82f6', // blue-500: 売上
+  cost: '#f59e0b', // amber-500: コスト
+  profit: '#22c55e', // green-500: 利益
+  deficit: '#ef4444', // red-500: 赤字
+  // 円グラフなど系列数が可変のグラフ用パレット
+  series: [
+    '#3b82f6', // blue-500
+    '#22c55e', // green-500
+    '#f59e0b', // amber-500
+    '#a855f7', // purple-500
+    '#ec4899', // pink-500
+    '#14b8a6', // teal-500
+    '#f97316', // orange-500
+    '#6366f1', // indigo-500
+  ],
+} as const;
+
+export const chartDefaults = {
+  height: 320,
+  margin: { top: 8, right: 16, bottom: 8, left: 16 },
+  gridStroke: '#e2e8f0', // slate-200
+  axisFontSize: 12,
+} as const;
+
+export function seriesColor(index: number): string {
+  return chartColors.series[index % chartColors.series.length];
+}
+
+export function formatHours(value: number): string {
+  return `${value.toLocaleString()}h`;
+}
+
+export function formatYen(value: number): string {
+  return new Intl.NumberFormat('ja-JP', { style: 'currency', currency: 'JPY' }).format(value);
+}
+
+export function formatPercent(value: number): string {
+  return `${value.toFixed(1)}%`;
+}


### PR DESCRIPTION
## 概要

Issue #54 (T179) の実装。Phase 8 フロントエンド（グラフ可視化）の共通基盤を追加。

## 変更内容

- `frontend/components/charts/chart-theme.ts`
  - 統一カラーテーマ（予定/実績、売上/コスト/利益/赤字、可変系列用8色パレット）
  - 共通デフォルト（高さ・マージン・グリッド色・軸フォントサイズ）
  - フォーマッタ（時間 `formatHours` / 円 `formatYen` / % `formatPercent`）
- `frontend/components/charts/chart-container.tsx`
  - `ChartContainer`: Card + タイトル + RechartsのResponsiveContainerラッパー
  - ローディング・エラー・空状態の表示を全グラフで統一

## 検証

- `npm run type-check` → パス
- 各グラフコンポーネント（#55〜#58 / T180〜T183）はこの基盤の上に実装予定

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)