### PR TITLE
feat(charts): 予実比較グラフコンポーネント実装 (T180)

### DIFF
--- a/frontend/components/charts/plan-actual-chart.tsx
+++ b/frontend/components/charts/plan-actual-chart.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { ChartContainer } from '@/components/charts/chart-container';
+import { chartColors, chartDefaults, formatHours } from '@/components/charts/chart-theme';
+import { PlanActualTaskData } from '@/types/analytics';
+
+interface PlanActualChartProps {
+  data?: PlanActualTaskData[];
+  isLoading?: boolean;
+  errorMessage?: string;
+}
+
+/**
+ * タスク別の予定工数と実績工数を比較する棒グラフ (T180)
+ * 実績が予定を超過したタスクは実績バーを警告色で表示する
+ */
+export function PlanActualChart({ data = [], isLoading, errorMessage }: PlanActualChartProps) {
+  return (
+    <ChartContainer
+      title="予実比較（タスク別）"
+      isLoading={isLoading}
+      errorMessage={errorMessage}
+      isEmpty={data.length === 0}
+      emptyMessage="タスクがありません"
+    >
+      <BarChart data={data} margin={chartDefaults.margin}>
+        <CartesianGrid strokeDasharray="3 3" stroke={chartDefaults.gridStroke} />
+        <XAxis dataKey="task_name" fontSize={chartDefaults.axisFontSize} />
+        <YAxis fontSize={chartDefaults.axisFontSize} tickFormatter={formatHours} />
+        <Tooltip formatter={(value: number) => formatHours(value)} />
+        <Legend />
+        <Bar dataKey="planned_hours" name="予定工数" fill={chartColors.planned} />
+        <Bar dataKey="actual_hours" name="実績工数" fill={chartColors.actual}>
+          {data.map((entry) => (
+            <Cell
+              key={entry.task_name}
+              fill={entry.variance > 0 ? chartColors.deficit : chartColors.actual}
+            />
+          ))}
+        </Bar>
+      </BarChart>
+    </ChartContainer>
+  );
+}

--- a/frontend/types/analytics.ts
+++ b/frontend/types/analytics.ts
@@ -1,0 +1,64 @@
+// Analytics API (GET /api/v1/projects/{id}/analytics/*, /api/v1/analytics/*) types
+
+export interface PlanActualTaskData {
+  task_name: string;
+  planned_hours: number;
+  actual_hours: number;
+  variance: number;
+}
+
+export interface PlanActualResponse {
+  tasks: PlanActualTaskData[];
+}
+
+export interface MemberCostData {
+  member_name: string;
+  cost: number;
+}
+
+export interface BudgetAnalyticsResponse {
+  revenue: number;
+  total_cost: number;
+  cost_breakdown: MemberCostData[];
+  profit: number;
+  profit_rate: number;
+}
+
+export type TrendPeriod = 'daily' | 'weekly' | 'monthly';
+
+export interface TrendDataPoint {
+  date: string;
+  planned_hours: number;
+  actual_hours: number;
+  cost: number;
+}
+
+export interface TrendResponse {
+  period: TrendPeriod;
+  data_points: TrendDataPoint[];
+}
+
+export interface TaskDistributionItem {
+  task_name: string;
+  actual_hours: number;
+  percentage: number;
+}
+
+export interface TaskDistributionResponse {
+  tasks: TaskDistributionItem[];
+}
+
+export interface ProjectComparisonItem {
+  project_id: string;
+  project_name: string;
+  planned_hours: number;
+  actual_hours: number;
+  revenue: number;
+  total_cost: number;
+  profit: number;
+  profit_rate: number;
+}
+
+export interface ProjectsComparisonResponse {
+  projects: ProjectComparisonItem[];
+}


### PR DESCRIPTION
## 概要

Issue #55 (T180) の実装。タスク別予実比較の棒グラフコンポーネントを追加。

## 変更内容

- `frontend/types/analytics.ts`: 分析API 5エンドポイント（#135）のレスポンス型定義（以降のグラフ #56〜#58 でも使用）
- `frontend/components/charts/plan-actual-chart.tsx`: `PlanActualChart`
  - 予定工数（グレー）と実績工数（青）のグループ棒グラフ
  - **実績が予定を超過したタスクは実績バーを赤で警告表示**（Cell単位の色分け）
  - ツールチップ・Y軸は `formatHours` で時間表記
  - #137 の `ChartContainer` / `chart-theme` を使用（ローディング・エラー・空状態対応）

## 検証

- `npm run type-check` → パス
- アナリティクスページへの組み込みは #60 (T185) で実施

Closes #55

🤖 Generated with [Claude Code](https://claude.com/claude-code)